### PR TITLE
Fix #55, Remove 'return;' from last line of void functions.

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -334,9 +334,6 @@ void DS_AppProcessMsg(const CFE_SB_Buffer_t *BufPtr)
             DS_AppStorePacket(MessageID, BufPtr);
             break;
     }
-
-    return;
-
 } /* End of DS_AppProcessMsg() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -489,9 +486,6 @@ void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             DS_AppData.CmdRejectedCounter++;
             break;
     }
-
-    return;
-
 } /* End of DS_AppProcessCmd() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -606,9 +600,6 @@ void DS_AppProcessHK(void)
     */
     CFE_SB_TimeStampMsg(&HkPacket.TlmHeader.Msg);
     CFE_SB_TransmitMsg(&HkPacket.TlmHeader.Msg, true);
-
-    return;
-
 } /* End of DS_AppProcessHK() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -642,9 +633,6 @@ void DS_AppStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
         */
         DS_FileStorePacket(MessageID, BufPtr);
     }
-
-    return;
-
 } /* End of DS_AppStorePacket() */
 
 /************************/

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -74,9 +74,6 @@ void DS_CmdNoop(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "NOOP command, Version %d.%d.%d.%d",
                           DS_MAJOR_VERSION, DS_MINOR_VERSION, DS_REVISION, DS_MISSION_REV);
     }
-
-    return;
-
 } /* End of DS_CmdNoop() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -137,9 +134,6 @@ void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(DS_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
     }
-
-    return;
-
 } /* End of DS_CmdReset() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -194,9 +188,6 @@ void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_ENADIS_CMD_EID, CFE_EVS_EventType_DEBUG, "APP STATE command: state = %d",
                           DS_AppStateCmd->EnableState);
     }
-
-    return;
-
 } /* End of DS_CmdSetAppState() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -310,9 +301,6 @@ void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
                               DS_FilterFileCmd->FilterParmsIndex, DS_FilterFileCmd->FileTableIndex);
         }
     }
-
-    return;
-
 } /* End of DS_CmdSetFilterFile() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -426,9 +414,6 @@ void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
                               DS_FilterTypeCmd->FilterParmsIndex, DS_FilterTypeCmd->FilterType);
         }
     }
-
-    return;
-
 } /* End of DS_CmdSetFilterType() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -547,9 +532,6 @@ void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
                               pFilterParms->Algorithm_O);
         }
     }
-
-    return;
-
 } /* End of DS_CmdSetFilterParms() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -627,9 +609,6 @@ void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
                           "DEST TYPE command: file table index = %d, filename type = %d",
                           DS_DestTypeCmd->FileTableIndex, DS_DestTypeCmd->FileNameType);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestType() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -706,9 +685,6 @@ void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
                           "DEST STATE command: file table index = %d, file state = %d", DS_DestStateCmd->FileTableIndex,
                           DS_DestStateCmd->EnableState);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestState() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -776,9 +752,6 @@ void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
                           "DEST PATH command: file table index = %d, pathname = '%s'",
                           (int)DS_DestPathCmd->FileTableIndex, DS_DestPathCmd->Pathname);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestPath() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -846,9 +819,6 @@ void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
                           "DEST BASE command: file table index = %d, base filename = '%s'",
                           (int)DS_DestBaseCmd->FileTableIndex, DS_DestBaseCmd->Basename);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestBase() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -916,9 +886,6 @@ void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
                           "DEST EXT command: file table index = %d, extension = '%s'",
                           (int)DS_DestExtCmd->FileTableIndex, DS_DestExtCmd->Extension);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestExt() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -996,9 +963,6 @@ void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
                           "DEST SIZE command: file table index = %d, size limit = %d",
                           (int)DS_DestSizeCmd->FileTableIndex, (int)DS_DestSizeCmd->MaxFileSize);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestSize() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1076,9 +1040,6 @@ void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
                           "DEST AGE command: file table index = %d, age limit = %d", (int)DS_DestAgeCmd->FileTableIndex,
                           (int)DS_DestAgeCmd->MaxFileAge);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestAge() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1169,9 +1130,6 @@ void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
                           "DEST COUNT command: file table index = %d, sequence count = %d",
                           (int)DS_DestCountCmd->FileTableIndex, (int)DS_DestCountCmd->SequenceCount);
     }
-
-    return;
-
 } /* End of DS_CmdSetDestCount() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1226,9 +1184,6 @@ void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_CLOSE_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE command: file table index = %d",
                           (int)DS_CloseFileCmd->FileTableIndex);
     }
-
-    return;
-
 } /* End of DS_CmdCloseFile() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1274,9 +1229,6 @@ void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(DS_CLOSE_ALL_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE ALL command");
     }
-
-    return;
-
 } /* End of DS_CmdCloseAll() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1377,9 +1329,6 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
         CFE_SB_TimeStampMsg(&DS_FileInfoPkt.TlmHeader.Msg);
         CFE_SB_TransmitMsg(&DS_FileInfoPkt.TlmHeader.Msg, true);
     }
-
-    return;
-
 } /* End of DS_CmdGetFileInfo() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1491,9 +1440,6 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
                           (unsigned long)CFE_SB_MsgIdToValue(DS_AddMidCmd->MessageID), (int)FilterTableIndex,
                           (int)HashTableIndex);
     }
-
-    return;
-
 } /* End of DS_CmdAddMID() */
 
 /************************/

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -260,9 +260,6 @@ void DS_FileStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
             DS_AppData.FilteredPktCounter++;
         }
     }
-
-    return;
-
 } /* End of DS_FileStorePacket() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -336,8 +333,6 @@ void DS_FileSetupWrite(int32 FileIndex, const CFE_SB_Buffer_t *BufPtr)
     ** If the write did not occur due to I/O error (create or write)
     **   then current state = file closed and destination disabled...
     */
-    return;
-
 } /* End of DS_FileSetupWrite() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -372,9 +367,6 @@ void DS_FileWriteData(int32 FileIndex, const void *FileData, uint32 DataLength)
         */
         DS_FileWriteError(FileIndex, DataLength, Result);
     }
-
-    return;
-
 } /* End of DS_FileWriteData() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -454,8 +446,6 @@ void DS_FileWriteHeader(int32 FileIndex)
         DS_FileWriteError(FileIndex, sizeof(CFE_FS_Header_t), Result);
     }
 #endif
-    return;
-
 } /* End of DS_FileWriteHeader() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -479,9 +469,6 @@ void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
     DS_FileCloseDest(FileIndex);
 
     FileStatus->FileState = DS_DISABLED;
-
-    return;
-
 } /* End of DS_FileWriteError() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -559,9 +546,6 @@ void DS_FileCreateDest(uint32 FileIndex)
             }
         }
     }
-
-    return;
-
 } /* End of DS_FileCreateDest() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -771,9 +755,6 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
         */
         Buffer[0] = '\0';
     }
-
-    return;
-
 } /* End of DS_FileCreateSequence() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -813,8 +794,6 @@ void DS_FileUpdateHeader(int32 FileIndex)
         DS_AppData.FileUpdateErrCounter++;
     }
 #endif
-    return;
-
 } /* End of DS_FileUpdateHeader() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -933,9 +912,6 @@ void DS_FileCloseDest(int32 FileIndex)
     ** Remove previous filename from status data...
     */
     memset(FileStatus->FileName, 0, sizeof(FileStatus->FileName));
-
-    return;
-
 } /* End of DS_FileCloseDest() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -975,9 +951,6 @@ void DS_FileTestAge(uint32 ElapsedSeconds)
             }
         }
     }
-
-    return;
-
 } /* End of DS_FileTestAge() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1034,9 +1007,6 @@ void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
         CFE_SB_TimeStampMsg(&PktBuf->Pkt.TlmHeader.Msg);
         CFE_SB_TransmitBuffer(&PktBuf->SBBuf, true);
     }
-
-    return;
-
 } /* End of DS_CmdGetCompleteFileInfo() */
 
 /************************/

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -282,9 +282,6 @@ void DS_TableManageDestFile(void)
             DS_TableUpdateCDS();
         }
     }
-
-    return;
-
 } /* End of DS_TableManageDestFile() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -389,9 +386,6 @@ void DS_TableManageFilter(void)
             DS_TableCreateHash();
         }
     }
-
-    return;
-
 } /* End of DS_TableManageFilter() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -849,9 +843,6 @@ void DS_TableSubscribe(void)
             CFE_SB_SubscribeEx(MessageID, DS_AppData.InputPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
         }
     }
-
-    return;
-
 } /* End of DS_TableSubscribe() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -884,9 +875,6 @@ void DS_TableUnsubscribe(void)
             CFE_SB_Unsubscribe(MessageID, DS_AppData.InputPipe);
         }
     }
-
-    return;
-
 } /* End of DS_TableUnsubscribe() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1008,9 +996,6 @@ void DS_TableUpdateCDS(void)
             DS_AppData.DataStoreHandle = CFE_ES_CDS_BAD_HANDLE;
         }
     }
-
-    return;
-
 } /* End of DS_TableUpdateCDS() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1076,9 +1061,6 @@ void DS_TableCreateHash(void)
     {
         DS_TableAddMsgID(DS_AppData.FilterTblPtr->Packet[FilterIndex].MessageID, FilterIndex);
     }
-
-    return;
-
 } /* End of DS_TableCreateHash() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #55
Removes all cases of redundant "return;" statements on the last line of void functions.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 