### PR TITLE
Fix #57, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -46,7 +46,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppData -- application global data structure                 */
+/* Application global data structure                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -54,7 +54,7 @@ DS_AppData_t DS_AppData;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppMain() -- application entry point and main process loop   */
+/* Application entry point and main process loop                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -166,12 +166,11 @@ void DS_AppMain(void)
     ** Let cFE kill the application (and any child tasks)...
     */
     CFE_ES_ExitApp(RunStatus);
-
-} /* End of DS_AppMain() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppInitialize() -- application initialization                */
+/* Application initialization                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -274,12 +273,11 @@ int32 DS_AppInitialize(void)
     }
 
     return Result;
-
-} /* End of DS_AppInitialize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessMsg() -- process Software Bus messages             */
+/* Process Software Bus messages                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -334,11 +332,11 @@ void DS_AppProcessMsg(const CFE_SB_Buffer_t *BufPtr)
             DS_AppStorePacket(MessageID, BufPtr);
             break;
     }
-} /* End of DS_AppProcessMsg() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessCmd() -- process application commands              */
+/* Process application commands                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -486,11 +484,11 @@ void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             DS_AppData.CmdRejectedCounter++;
             break;
     }
-} /* End of DS_AppProcessCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessHK() -- process hk request command                 */
+/* Process hk request command                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -600,17 +598,16 @@ void DS_AppProcessHK(void)
     */
     CFE_SB_TimeStampMsg(&HkPacket.TlmHeader.Msg);
     CFE_SB_TransmitMsg(&HkPacket.TlmHeader.Msg, true);
-} /* End of DS_AppProcessHK() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppStorePacket() -- packet storage pre-processor             */
+/* Packet storage pre-processor                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_AppStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
 {
-
     if (DS_AppData.AppEnableState == DS_DISABLED)
     {
         /*
@@ -633,8 +630,4 @@ void DS_AppStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
         */
         DS_FileStorePacket(MessageID, BufPtr);
     }
-} /* End of DS_AppStorePacket() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/ds_app.h
+++ b/fsw/src/ds_app.h
@@ -62,7 +62,6 @@ typedef struct
     uint16    FileState;                        /**< \brief Current file enable/disable state */
     uint16    Unused;                           /**< \brief Unused - structure padding */
     char      FileName[DS_TOTAL_FNAME_BUFSIZE]; /**< \brief Current filename (path+base+seq+ext) */
-
 } DS_AppFileStatus_t;
 
 /**
@@ -103,7 +102,6 @@ typedef struct
 
     DS_HashLink_t  HashLinks[DS_PACKETS_IN_FILTER_TABLE]; /**< \brief Hash table linked list elements */
     DS_HashLink_t *HashTable[DS_HASH_TABLE_ENTRIES];      /**< \brief Each hash table entry is a linked list */
-
 } DS_AppData_t;
 
 /** \brief DS global data structure reference */

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -42,7 +42,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdNoop() - NOOP command                                     */
+/* NOOP command                                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -74,11 +74,11 @@ void DS_CmdNoop(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "NOOP command, Version %d.%d.%d.%d",
                           DS_MAJOR_VERSION, DS_MINOR_VERSION, DS_REVISION, DS_MISSION_REV);
     }
-} /* End of DS_CmdNoop() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdReset() - reset hk telemetry counters command             */
+/* Reset hk telemetry counters command                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -134,11 +134,11 @@ void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(DS_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
     }
-} /* End of DS_CmdReset() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetAppState() - set application ena/dis state             */
+/* Set application ena/dis state                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -188,11 +188,11 @@ void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_ENADIS_CMD_EID, CFE_EVS_EventType_DEBUG, "APP STATE command: state = %d",
                           DS_AppStateCmd->EnableState);
     }
-} /* End of DS_CmdSetAppState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterFile() - set packet filter file index            */
+/* Set packet filter file index                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -301,11 +301,11 @@ void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
                               DS_FilterFileCmd->FilterParmsIndex, DS_FilterFileCmd->FileTableIndex);
         }
     }
-} /* End of DS_CmdSetFilterFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterType() - set pkt filter filename type            */
+/* Set pkt filter filename type                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -414,11 +414,11 @@ void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
                               DS_FilterTypeCmd->FilterParmsIndex, DS_FilterTypeCmd->FilterType);
         }
     }
-} /* End of DS_CmdSetFilterType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterParms() - set packet filter parameters           */
+/* Set packet filter parameters                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -532,11 +532,11 @@ void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
                               pFilterParms->Algorithm_O);
         }
     }
-} /* End of DS_CmdSetFilterParms() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestType() - set destination filename type             */
+/* Set destination filename type                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -609,11 +609,11 @@ void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
                           "DEST TYPE command: file table index = %d, filename type = %d",
                           DS_DestTypeCmd->FileTableIndex, DS_DestTypeCmd->FileNameType);
     }
-} /* End of DS_CmdSetDestType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestState() - set dest file ena/dis state              */
+/* Set dest file ena/dis state                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -685,11 +685,11 @@ void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
                           "DEST STATE command: file table index = %d, file state = %d", DS_DestStateCmd->FileTableIndex,
                           DS_DestStateCmd->EnableState);
     }
-} /* End of DS_CmdSetDestState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestPath() - set path portion of filename              */
+/* Set path portion of filename                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -752,11 +752,11 @@ void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
                           "DEST PATH command: file table index = %d, pathname = '%s'",
                           (int)DS_DestPathCmd->FileTableIndex, DS_DestPathCmd->Pathname);
     }
-} /* End of DS_CmdSetDestPath() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestBase() - set base portion of filename              */
+/* Set base portion of filename                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -819,11 +819,11 @@ void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
                           "DEST BASE command: file table index = %d, base filename = '%s'",
                           (int)DS_DestBaseCmd->FileTableIndex, DS_DestBaseCmd->Basename);
     }
-} /* End of DS_CmdSetDestBase() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestExt() - set extension portion of filename          */
+/* Set extension portion of filename                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -886,11 +886,11 @@ void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
                           "DEST EXT command: file table index = %d, extension = '%s'",
                           (int)DS_DestExtCmd->FileTableIndex, DS_DestExtCmd->Extension);
     }
-} /* End of DS_CmdSetDestExt() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestSize() - set maximum file size limit               */
+/* Set maximum file size limit                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -963,11 +963,11 @@ void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
                           "DEST SIZE command: file table index = %d, size limit = %d",
                           (int)DS_DestSizeCmd->FileTableIndex, (int)DS_DestSizeCmd->MaxFileSize);
     }
-} /* End of DS_CmdSetDestSize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestAge() - set maximum file age limit                 */
+/* Set maximum file age limit                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1040,11 +1040,11 @@ void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
                           "DEST AGE command: file table index = %d, age limit = %d", (int)DS_DestAgeCmd->FileTableIndex,
                           (int)DS_DestAgeCmd->MaxFileAge);
     }
-} /* End of DS_CmdSetDestAge() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestCount() - set seq cnt portion of filename          */
+/* Set seq cnt portion of filename                                 */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1130,11 +1130,11 @@ void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
                           "DEST COUNT command: file table index = %d, sequence count = %d",
                           (int)DS_DestCountCmd->FileTableIndex, (int)DS_DestCountCmd->SequenceCount);
     }
-} /* End of DS_CmdSetDestCount() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdCloseFile() - close destination file                      */
+/* Close destination file                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1184,11 +1184,11 @@ void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
         CFE_EVS_SendEvent(DS_CLOSE_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE command: file table index = %d",
                           (int)DS_CloseFileCmd->FileTableIndex);
     }
-} /* End of DS_CmdCloseFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdCloseAll() - close all open destination files             */
+/* Close all open destination files                                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1229,11 +1229,11 @@ void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
 
         CFE_EVS_SendEvent(DS_CLOSE_ALL_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE ALL command");
     }
-} /* End of DS_CmdCloseAll() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdGetFileInfo() - get file info packet                      */
+/* Get file info packet                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1329,11 +1329,11 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
         CFE_SB_TimeStampMsg(&DS_FileInfoPkt.TlmHeader.Msg);
         CFE_SB_TransmitMsg(&DS_FileInfoPkt.TlmHeader.Msg, true);
     }
-} /* End of DS_CmdGetFileInfo() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdAddMID() - add message ID to packet filter table          */
+/* Add message ID to packet filter table                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1440,8 +1440,4 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
                           (unsigned long)CFE_SB_MsgIdToValue(DS_AddMidCmd->MessageID), (int)FilterTableIndex,
                           (int)HashTableIndex);
     }
-} /* End of DS_CmdAddMID() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -176,12 +176,11 @@ bool DS_IsPacketFiltered(CFE_MSG_Message_t *MessagePtr, uint16 FilterType, uint1
     }
 
     return PacketIsFiltered;
-
-} /* End of DS_IsPacketFiltered() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileStorePacket() - store packet in file(s)                  */
+/* Store packet in file(s)                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -260,11 +259,11 @@ void DS_FileStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
             DS_AppData.FilteredPktCounter++;
         }
     }
-} /* End of DS_FileStorePacket() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileSetupWrite() - prepare to write packet data to file      */
+/* Prepare to write packet data to file                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -333,11 +332,11 @@ void DS_FileSetupWrite(int32 FileIndex, const CFE_SB_Buffer_t *BufPtr)
     ** If the write did not occur due to I/O error (create or write)
     **   then current state = file closed and destination disabled...
     */
-} /* End of DS_FileSetupWrite() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteData() - write data to destination file             */
+/* Write data to destination file                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -367,11 +366,11 @@ void DS_FileWriteData(int32 FileIndex, const void *FileData, uint32 DataLength)
         */
         DS_FileWriteError(FileIndex, DataLength, Result);
     }
-} /* End of DS_FileWriteData() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteHeader() - write header to destination file         */
+/* Write header to destination file                                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -444,11 +443,11 @@ void DS_FileWriteHeader(int32 FileIndex)
         DS_FileWriteError(FileIndex, sizeof(CFE_FS_Header_t), Result);
     }
 #endif
-} /* End of DS_FileWriteHeader() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteError() - file write error handler                  */
+/* File write error handler                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
@@ -467,11 +466,11 @@ void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
     DS_FileCloseDest(FileIndex);
 
     FileStatus->FileState = DS_DISABLED;
-} /* End of DS_FileWriteError() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCreateDest() - create destination file                   */
+/* Create destination file                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCreateDest(uint32 FileIndex)
@@ -544,7 +543,7 @@ void DS_FileCreateDest(uint32 FileIndex)
             }
         }
     }
-} /* End of DS_FileCreateDest() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -622,12 +621,11 @@ void DS_FileCreateName(uint32 FileIndex)
                           "FILE NAME error: Path empty. dest = %d, path = '%s'", (int)FileIndex, DestFile->Pathname);
         DS_AppData.FileStatus[FileIndex].FileState = DS_DISABLED;
     }
-
-} /* End of DS_FileCreateName() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCreateSequence() - set text from count or time           */
+/* Set text from count or time                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
@@ -753,11 +751,11 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
         */
         Buffer[0] = '\0';
     }
-} /* End of DS_FileCreateSequence() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileUpdateHeader() - update destination file header          */
+/* Update destination file header                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -792,11 +790,11 @@ void DS_FileUpdateHeader(int32 FileIndex)
         DS_AppData.FileUpdateErrCounter++;
     }
 #endif
-} /* End of DS_FileUpdateHeader() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCloseDest() - close destination file                     */
+/* Close destination file                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCloseDest(int32 FileIndex)
@@ -910,11 +908,11 @@ void DS_FileCloseDest(int32 FileIndex)
     ** Remove previous filename from status data...
     */
     memset(FileStatus->FileName, 0, sizeof(FileStatus->FileName));
-} /* End of DS_FileCloseDest() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileTestAge() -- file age processor                          */
+/* File age processor                                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileTestAge(uint32 ElapsedSeconds)
@@ -949,11 +947,11 @@ void DS_FileTestAge(uint32 ElapsedSeconds)
             }
         }
     }
-} /* End of DS_FileTestAge() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileTransmit() - transmit file info                          */
+/* Transmit file info                                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1005,8 +1003,4 @@ void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
         CFE_SB_TimeStampMsg(&PktBuf->Pkt.TlmHeader.Msg);
         CFE_SB_TransmitBuffer(&PktBuf->SBBuf, true);
     }
-} /* End of DS_CmdGetCompleteFileInfo() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/ds_file.h
+++ b/fsw/src/ds_file.h
@@ -47,7 +47,6 @@ typedef struct
     uint16 FileNameType;   /**< \brief Filename type - count vs time */
 
     char FileName[DS_TOTAL_FNAME_BUFSIZE]; /**< \brief On-board filename */
-
 } DS_FileHeader_t;
 #endif
 

--- a/fsw/src/ds_msg.h
+++ b/fsw/src/ds_msg.h
@@ -40,7 +40,6 @@
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
-
 } DS_NoopCmd_t;
 
 /**
@@ -50,9 +49,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
-
 } DS_ResetCmd_t;
 
 /**
@@ -66,7 +63,6 @@ typedef struct
 
     uint16 EnableState; /**< \brief Application enable/disable state */
     uint16 Padding;     /**< \brief Structure Padding on 32-bit boundaries */
-
 } DS_AppStateCmd_t;
 
 /**
@@ -82,7 +78,6 @@ typedef struct
                                    \details DS defines Message ID zero to be unused */
     uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
     uint16 FileTableIndex;    /**< \brief Index into Destination File Table */
-
 } DS_FilterFileCmd_t;
 
 /**
@@ -92,14 +87,12 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
     uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
     uint16 FilterType;        /**< \brief Filter type (packet count or time) */
-
 } DS_FilterTypeCmd_t;
 
 /**
@@ -117,7 +110,6 @@ typedef struct
     uint16 Algorithm_N;       /**< \brief Algorithm value N (pass this many) */
     uint16 Algorithm_X;       /**< \brief Algorithm value X (out of this many) */
     uint16 Algorithm_O;       /**< \brief Algorithm value O (at this offset) */
-
 } DS_FilterParmsCmd_t;
 
 /**
@@ -131,7 +123,6 @@ typedef struct
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 FileNameType;   /**< \brief Filename type - count vs time */
-
 } DS_DestTypeCmd_t;
 
 /**
@@ -145,7 +136,6 @@ typedef struct
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 EnableState;    /**< \brief File enable/disable state */
-
 } DS_DestStateCmd_t;
 
 /**
@@ -155,13 +145,11 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
     uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
     char   Pathname[DS_PATHNAME_BUFSIZE]; /**< \brief Path portion of filename */
-
 } DS_DestPathCmd_t;
 
 /**
@@ -171,13 +159,11 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
     uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
     char   Basename[DS_BASENAME_BUFSIZE]; /**< \brief Base portion of filename */
-
 } DS_DestBaseCmd_t;
 
 /**
@@ -192,7 +178,6 @@ typedef struct
     uint16 FileTableIndex;                  /**< \brief Index into Destination File Table */
     uint16 Padding;                         /**< \brief Structure Padding on 32-bit boundaries */
     char   Extension[DS_EXTENSION_BUFSIZE]; /**< \brief Extension portion of filename */
-
 } DS_DestExtCmd_t;
 
 /**
@@ -207,7 +192,6 @@ typedef struct
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
     uint32 MaxFileSize;    /**< \brief Max file size (bytes) before re-open */
-
 } DS_DestSizeCmd_t;
 
 /**
@@ -223,7 +207,6 @@ typedef struct
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
 
     uint32 MaxFileAge; /**< \brief Max file age (seconds) */
-
 } DS_DestAgeCmd_t;
 
 /**
@@ -239,7 +222,6 @@ typedef struct
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
 
     uint32 SequenceCount; /**< \brief Sequence count portion of filename */
-
 } DS_DestCountCmd_t;
 
 /**
@@ -253,7 +235,6 @@ typedef struct
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
-
 } DS_CloseFileCmd_t;
 
 /**
@@ -263,9 +244,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
-
 } DS_CloseAllCmd_t;
 
 /**
@@ -275,9 +254,7 @@ typedef struct
  */
 typedef struct
 {
-
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
-
 } DS_GetFileInfoCmd_t;
 
 /**
@@ -290,7 +267,6 @@ typedef struct
     CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
-
 } DS_AddMidCmd_t;
 
 /**\}*/

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -40,7 +40,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableInit() - DS application table initialization            */
+/* DS application table initialization                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -174,12 +174,11 @@ int32 DS_TableInit(void)
     }
 
     return Result1;
-
-} /* End of DS_TableInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableManageDestFile() - manage table data updates            */
+/* Manage table data updates                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -282,11 +281,11 @@ void DS_TableManageDestFile(void)
             DS_TableUpdateCDS();
         }
     }
-} /* End of DS_TableManageDestFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableManageFilter() - manage table data updates              */
+/* Manage table data updates                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -386,11 +385,11 @@ void DS_TableManageFilter(void)
             DS_TableCreateHash();
         }
     }
-} /* End of DS_TableManageFilter() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyDestFile() - validate table data                  */
+/* Validate table data                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -433,12 +432,11 @@ int32 DS_TableVerifyDestFile(const void *TableData)
                       DescResult, (int)CountGood, (int)CountBad, (int)CountUnused);
 
     return Result;
-
-} /* End of DS_TableVerifyDestFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyDestFileEntry() - verify dest table entry         */
+/* Verify dest table entry                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -504,12 +502,11 @@ bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableI
     }
 
     return Result;
-
-} /* End of DS_TableVerifyDestFileEntry() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFilter() - validate table data                    */
+/* Validate table data                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -558,12 +555,11 @@ int32 DS_TableVerifyFilter(const void *TableData)
                       DescResult, (int)CountGood, (int)CountBad, (int)CountUnused);
 
     return Result;
-
-} /* End of DS_TableVerifyFilter() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFilterEntry() - verify filter table entry         */
+/* Verify filter table entry                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -636,12 +632,11 @@ bool DS_TableVerifyFilterEntry(DS_PacketEntry_t *PacketEntry, int32 TableIndex, 
     }
 
     return Result;
-
-} /* End of DS_TableVerifyFilterEntry() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableEntryUnused() - find unused table entries               */
+/* Find unused table entries                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -661,12 +656,11 @@ bool DS_TableEntryUnused(const void *TableEntry, int32 BufferSize)
     }
 
     return Result;
-
-} /* End of DS_TableEntryUnused() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFileIndex() - verify dest file index              */
+/* Verify dest file index                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -680,12 +674,11 @@ bool DS_TableVerifyFileIndex(uint16 FileTableIndex)
     }
 
     return Result;
-
-} /* End of DS_TableVerifyFileIndex() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyParms() - verify algorithm parameters             */
+/* Verify algorithm parameters                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -715,12 +708,11 @@ bool DS_TableVerifyParms(uint16 Algorithm_N, uint16 Algorithm_X, uint16 Algorith
     }
 
     return Result;
-
-} /* End of DS_TableVerifyParms() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyType() - verify filter or filename type           */
+/* Verify filter or filename type                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -734,12 +726,11 @@ bool DS_TableVerifyType(uint16 TimeVsCount)
     }
 
     return Result;
-
-} /* End of DS_TableVerifyType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyState() - verify file ena/dis state               */
+/* Verify file ena/dis state                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -753,12 +744,11 @@ bool DS_TableVerifyState(uint16 EnableState)
     }
 
     return Result;
-
-} /* End of DS_TableVerifyState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifySize() - verify file size limit                   */
+/* Verify file size limit                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -772,12 +762,11 @@ bool DS_TableVerifySize(uint32 MaxFileSize)
     }
 
     return Result;
-
-} /* End of DS_TableVerifySize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyAge() - verify file age limit                     */
+/* Verify file age limit                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -791,12 +780,11 @@ bool DS_TableVerifyAge(uint32 MaxFileAge)
     }
 
     return Result;
-
-} /* End of DS_TableVerifyAge() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyCount() - verify sequence count                   */
+/* Verify sequence count                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -810,12 +798,11 @@ bool DS_TableVerifyCount(uint32 SequenceCount)
     }
 
     return Result;
-
-} /* End of DS_TableVerifyCount() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableSubscribe() - process new filter table                  */
+/* Process new filter table                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -843,11 +830,11 @@ void DS_TableSubscribe(void)
             CFE_SB_SubscribeEx(MessageID, DS_AppData.InputPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
         }
     }
-} /* End of DS_TableSubscribe() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableUnsubscribe() - process old filter table                */
+/* Process old filter table                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -875,11 +862,11 @@ void DS_TableUnsubscribe(void)
             CFE_SB_Unsubscribe(MessageID, DS_AppData.InputPipe);
         }
     }
-} /* End of DS_TableUnsubscribe() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableCreateCDS() - create DS storage area in CDS             */
+/* Create DS storage area in CDS                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -946,12 +933,11 @@ int32 DS_TableCreateCDS(void)
     }
 
     return Result;
-
-} /* End of DS_TableCreateCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableUpdateCDS() - update DS storage area in CDS             */
+/* Update DS storage area in CDS                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -996,11 +982,11 @@ void DS_TableUpdateCDS(void)
             DS_AppData.DataStoreHandle = CFE_ES_CDS_BAD_HANDLE;
         }
     }
-} /* End of DS_TableUpdateCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableHashFunction() - convert messageID to hash table index  */
+/* Convert messageID to hash table index                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1038,12 +1024,11 @@ uint32 DS_TableHashFunction(CFE_SB_MsgId_t MessageID)
     **     (can now go directly to the correct filter table entry)
     */
     return ((uint32)(CFE_SB_MsgIdToValue(MessageID) & DS_HASH_TABLE_MASK));
-
-} /* End of DS_TableHashFunction() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableCreateHash() - create and populate hash table           */
+/* Create and populate hash table                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1061,11 +1046,11 @@ void DS_TableCreateHash(void)
     {
         DS_TableAddMsgID(DS_AppData.FilterTblPtr->Packet[FilterIndex].MessageID, FilterIndex);
     }
-} /* End of DS_TableCreateHash() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableAddMsgID() - get hash table index for MID               */
+/* Get hash table index for MID                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1106,12 +1091,11 @@ int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
     }
 
     return HashIndex;
-
-} /* End of DS_TableAddMsgID() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableFindMsgID() - get filter table index for MID            */
+/* Get filter table index for MID                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -1150,9 +1134,4 @@ int32 DS_TableFindMsgID(CFE_SB_MsgId_t MessageID)
     }
 
     return FilterTableIndex;
-
-} /* End of DS_TableFindMsgID() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/ds_table.h
+++ b/fsw/src/ds_table.h
@@ -44,7 +44,6 @@ typedef struct DS_HashTag
     uint16         Index;     /**< \brief DS filter table entry index */
 
     struct DS_HashTag *Next; /**< \brief Next hash table linked list element */
-
 } DS_HashLink_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -62,7 +61,6 @@ typedef struct
     uint16 Algorithm_N; /**< \brief Algorithm value N (pass this many) */
     uint16 Algorithm_X; /**< \brief Algorithm value X (out of this many) */
     uint16 Algorithm_O; /**< \brief Algorithm value O (at this offset) */
-
 } DS_FilterParms_t;
 
 /** \brief DS Filter Table Packet Entry */
@@ -71,7 +69,6 @@ typedef struct
     CFE_SB_MsgId_t MessageID; /**< \brief Packet MessageID (may be cmd or tlm) */
 
     DS_FilterParms_t Filter[DS_FILTERS_PER_PACKET]; /**< \brief One entry for each packet destination */
-
 } DS_PacketEntry_t;
 
 /** \brief DS Filter Table */
@@ -79,7 +76,6 @@ typedef struct
 {
     char             Descriptor[DS_DESCRIPTOR_BUFSIZE];  /**< \brief Description such as "Safehold Filter Table" */
     DS_PacketEntry_t Packet[DS_PACKETS_IN_FILTER_TABLE]; /**< \brief One entry for each filtered packet */
-
 } DS_FilterTable_t;
 
 /**
@@ -105,7 +101,6 @@ typedef struct
     uint32 MaxFileAge;  /**< \brief Max file age (seconds) */
 
     uint32 SequenceCount; /**< \brief Sequence count portion of filename */
-
 } DS_DestFileEntry_t;
 
 /** \brief DS Destination File Table */
@@ -113,7 +108,6 @@ typedef struct
 {
     char               Descriptor[DS_DESCRIPTOR_BUFSIZE]; /**< \brief Description such as "HK Telemetry File" */
     DS_DestFileEntry_t File[DS_DEST_FILE_CNT];            /**< \brief One entry for each destination data file */
-
 } DS_DestFileTable_t;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/unit-test/ds_app_tests.c
+++ b/unit-test/ds_app_tests.c
@@ -80,7 +80,7 @@ void DS_AppMain_Test_Nominal(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 0);
-} /* end DS_AppMain_Test_Nominal */
+}
 
 void DS_AppMain_Test_AppInitializeError(void)
 {
@@ -103,7 +103,7 @@ void DS_AppMain_Test_AppInitializeError(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_CRITICAL);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
-} /* end DS_AppMain_Test_AppInitializeError */
+}
 
 void DS_AppMain_Test_SBError(void)
 {
@@ -123,7 +123,7 @@ void DS_AppMain_Test_SBError(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_CRITICAL);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
     UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
-} /* end DS_AppMain_Test_SBError */
+}
 
 void DS_AppMain_Test_SBTimeout(void)
 {
@@ -140,8 +140,7 @@ void DS_AppMain_Test_SBTimeout(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_STUB_COUNT(DS_FileTestAge, 1);
-
-} /* end DS_AppMain_Test_SBTimeout */
+}
 
 void DS_AppInitialize_Test_Nominal(void)
 {
@@ -163,7 +162,7 @@ void DS_AppInitialize_Test_Nominal(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-} /* end DS_AppInitialize_Test_Nominal */
+}
 
 void DS_AppInitialize_Test_EVSRegisterError(void)
 {
@@ -185,8 +184,7 @@ void DS_AppInitialize_Test_EVSRegisterError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_AppInitialize_Test_EVSRegisterError */
+}
 
 void DS_AppInitialize_Test_SBCreatePipeError(void)
 {
@@ -208,8 +206,7 @@ void DS_AppInitialize_Test_SBCreatePipeError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_AppInitialize_Test_SBCreatePipeError */
+}
 
 void DS_AppInitialize_Test_SBSubscribeHKError(void)
 {
@@ -231,8 +228,7 @@ void DS_AppInitialize_Test_SBSubscribeHKError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_AppInitialize_Test_SBSubscribeHKError */
+}
 
 void DS_AppInitialize_Test_SBSubscribeDSError(void)
 {
@@ -254,8 +250,7 @@ void DS_AppInitialize_Test_SBSubscribeDSError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_AppInitialize_Test_SBSubscribeDSError */
+}
 
 void DS_AppProcessMsg_Test_CmdStore(void)
 {
@@ -289,8 +284,7 @@ void DS_AppProcessMsg_Test_CmdStore(void)
 
     /* event message that would normally be sent by noop in production code is
      * stubbed out for the purposes of this test */
-
-} /* end DS_AppProcessMsg_Test_CmdStore */
+}
 
 void DS_AppProcessMsg_Test_CmdNoStore(void)
 {
@@ -324,8 +318,7 @@ void DS_AppProcessMsg_Test_CmdNoStore(void)
 
     /* event message that would normally be sent by noop in production code is
      * stubbed out for the purposes of this test */
-
-} /* end DS_AppProcessMsg_Test_CmdNoStore */
+}
 
 void DS_AppProcessMsg_Test_HKStore(void)
 {
@@ -358,8 +351,7 @@ void DS_AppProcessMsg_Test_HKStore(void)
     UtAssert_INT32_EQ(DS_AppData.DisabledPktCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppProcessMsg_Test_HKStore */
+}
 
 void DS_AppProcessMsg_Test_HKNoStore(void)
 {
@@ -392,12 +384,10 @@ void DS_AppProcessMsg_Test_HKNoStore(void)
     UtAssert_INT32_EQ(DS_AppData.DisabledPktCounter, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppProcessMsg_Test_HKNoStore */
+}
 
 void DS_AppProcessMsg_Test_HKInvalidRequest(void)
 {
-
     size_t         forced_Size  = 0;
     CFE_SB_MsgId_t forced_MsgID = CFE_SB_ValueToMsgId(DS_SEND_HK_MID);
 
@@ -411,12 +401,10 @@ void DS_AppProcessMsg_Test_HKInvalidRequest(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_HK_REQUEST_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_AppProcessMsg_Test_HKInvalidRequest */
+}
 
 void DS_AppProcessMsg_Test_UnknownMID(void)
 {
-
     size_t         forced_Size  = 0;
     CFE_SB_MsgId_t forced_MsgID = DS_UT_MID_1;
 
@@ -428,8 +416,7 @@ void DS_AppProcessMsg_Test_UnknownMID(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppProcessMsg_Test_UnknownMID */
+}
 
 void DS_AppProcessCmd_Test_Noop(void)
 {
@@ -446,8 +433,7 @@ void DS_AppProcessCmd_Test_Noop(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdNoop, 1);
-
-} /* end DS_AppProcessCmd_Test_Noop */
+}
 
 void DS_AppProcessCmd_Test_Reset(void)
 {
@@ -464,8 +450,7 @@ void DS_AppProcessCmd_Test_Reset(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdReset, 1);
-
-} /* end DS_AppProcessCmd_Test_Reset */
+}
 
 void DS_AppProcessCmd_Test_SetAppState(void)
 {
@@ -482,7 +467,7 @@ void DS_AppProcessCmd_Test_SetAppState(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetAppState, 1);
-} /* end DS_AppProcessCmd_Test_SetAppState */
+}
 
 void DS_AppProcessCmd_Test_SetFilterFile(void)
 {
@@ -499,7 +484,7 @@ void DS_AppProcessCmd_Test_SetFilterFile(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetFilterFile, 1);
-} /* end DS_AppProcessCmd_Test_SetFilterFile */
+}
 
 void DS_AppProcessCmd_Test_SetFilterType(void)
 {
@@ -516,8 +501,7 @@ void DS_AppProcessCmd_Test_SetFilterType(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetFilterType, 1);
-
-} /* end DS_AppProcessCmd_Test_SetFilterType */
+}
 
 void DS_AppProcessCmd_Test_SetFilterParms(void)
 {
@@ -534,7 +518,7 @@ void DS_AppProcessCmd_Test_SetFilterParms(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetFilterParms, 1);
-} /* end DS_AppProcessCmd_Test_SetFilterParms */
+}
 
 void DS_AppProcessCmd_Test_SetDestType(void)
 {
@@ -551,7 +535,7 @@ void DS_AppProcessCmd_Test_SetDestType(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestType, 1);
-} /* end DS_AppProcessCmd_Test_SetDestType */
+}
 
 void DS_AppProcessCmd_Test_SetDestState(void)
 {
@@ -568,7 +552,7 @@ void DS_AppProcessCmd_Test_SetDestState(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestState, 1);
-} /* end DS_AppProcessCmd_Test_SetDestState */
+}
 
 void DS_AppProcessCmd_Test_SetDestPath(void)
 {
@@ -585,7 +569,7 @@ void DS_AppProcessCmd_Test_SetDestPath(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestPath, 1);
-} /* end DS_AppProcessCmd_Test_SetDestPath */
+}
 
 void DS_AppProcessCmd_Test_SetDestBase(void)
 {
@@ -602,7 +586,7 @@ void DS_AppProcessCmd_Test_SetDestBase(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestBase, 1);
-} /* end DS_AppProcessCmd_Test_SetDestBase */
+}
 
 void DS_AppProcessCmd_Test_SetDestExt(void)
 {
@@ -619,8 +603,7 @@ void DS_AppProcessCmd_Test_SetDestExt(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestExt, 1);
-
-} /* end DS_AppProcessCmd_Test_SetDestExt */
+}
 
 void DS_AppProcessCmd_Test_SetDestSize(void)
 {
@@ -637,7 +620,7 @@ void DS_AppProcessCmd_Test_SetDestSize(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestSize, 1);
-} /* end DS_AppProcessCmd_Test_SetDestSize */
+}
 
 void DS_AppProcessCmd_Test_SetDestAge(void)
 {
@@ -654,7 +637,7 @@ void DS_AppProcessCmd_Test_SetDestAge(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestAge, 1);
-} /* end DS_AppProcessCmd_Test_SetDestAge */
+}
 
 void DS_AppProcessCmd_Test_SetDestCount(void)
 {
@@ -671,7 +654,7 @@ void DS_AppProcessCmd_Test_SetDestCount(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdSetDestCount, 1);
-} /* end DS_AppProcessCmd_Test_SetDestCount */
+}
 
 void DS_AppProcessCmd_Test_CloseFile(void)
 {
@@ -694,7 +677,7 @@ void DS_AppProcessCmd_Test_CloseFile(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdCloseFile, 1);
-} /* end DS_AppProcessCmd_Test_CloseFile */
+}
 
 void DS_AppProcessCmd_Test_GetFileInfo(void)
 {
@@ -711,7 +694,7 @@ void DS_AppProcessCmd_Test_GetFileInfo(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdGetFileInfo, 1);
-} /* end DS_AppProcessCmd_Test_GetFileInfo */
+}
 
 void DS_AppProcessCmd_Test_AddMID(void)
 {
@@ -728,7 +711,7 @@ void DS_AppProcessCmd_Test_AddMID(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdAddMID, 1);
-} /* end DS_AppProcessCmd_Test_AddMID */
+}
 
 void DS_AppProcessCmd_Test_CloseAll(void)
 {
@@ -751,7 +734,7 @@ void DS_AppProcessCmd_Test_CloseAll(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CmdCloseAll, 1);
-} /* end DS_AppProcessCmd_Test_CloseAll */
+}
 
 void DS_AppProcessCmd_Test_InvalidCommandCode(void)
 {
@@ -770,8 +753,7 @@ void DS_AppProcessCmd_Test_InvalidCommandCode(void)
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end DS_AppProcessCmd_Test_InvalidCommandCode */
+}
 
 void DS_AppProcessHK_Test(void)
 {
@@ -803,8 +785,7 @@ void DS_AppProcessHK_Test(void)
     UtAssert_BOOL_TRUE(TLM_STRUCT_DATA_IS_32_ALIGNED(DS_HkPacket_t));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppProcessHK_Test */
+}
 
 void DS_AppProcessHK_Test_SnprintfFail(void)
 {
@@ -898,7 +879,7 @@ void DS_AppStorePacket_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(DS_FileStorePacket, 1);
-} /* end DS_AppStorePacket_Test_Nominal */
+}
 
 void DS_AppStorePacket_Test_DSDisabled(void)
 {
@@ -920,8 +901,7 @@ void DS_AppStorePacket_Test_DSDisabled(void)
     UtAssert_UINT32_EQ(DS_AppData.DisabledPktCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppStorePacket_Test_DSDisabled */
+}
 
 void DS_AppStorePacket_Test_FilterTableNotLoaded(void)
 {
@@ -944,8 +924,7 @@ void DS_AppStorePacket_Test_FilterTableNotLoaded(void)
     UtAssert_UINT32_EQ(DS_AppData.IgnoredPktCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppStorePacket_Test_FilterTableNotLoaded */
+}
 
 void DS_AppStorePacket_Test_DestFileTableNotLoaded(void)
 {
@@ -968,8 +947,7 @@ void DS_AppStorePacket_Test_DestFileTableNotLoaded(void)
     UtAssert_UINT32_EQ(DS_AppData.IgnoredPktCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_AppStorePacket_Test_DestFileTableNotLoaded */
+}
 
 void UtTest_Setup(void)
 {
@@ -1019,8 +997,4 @@ void UtTest_Setup(void)
     UT_DS_TEST_ADD(DS_AppStorePacket_Test_DSDisabled);
     UT_DS_TEST_ADD(DS_AppStorePacket_Test_FilterTableNotLoaded);
     UT_DS_TEST_ADD(DS_AppStorePacket_Test_DestFileTableNotLoaded);
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -56,7 +56,6 @@ uint8 call_count_CFE_EVS_SendEvent;
 
 void DS_CmdNoop_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_NoopCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_NOOP_CC;
@@ -88,12 +87,10 @@ void DS_CmdNoop_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_NoopCmd_t), "DS_NoopCmd_t is 32-bit aligned");
-
-} /* end DS_CmdNoop_Test_Nominal */
+}
 
 void DS_CmdNoop_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_NoopCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_NOOP_CC;
@@ -123,12 +120,10 @@ void DS_CmdNoop_Test_InvalidCommandLength(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end DS_CmdNoop_Test_InvalidCommandLength */
+}
 
 void DS_CmdReset_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_ResetCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_RESET_CC;
@@ -173,12 +168,10 @@ void DS_CmdReset_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_ResetCmd_t), "DS_ResetCmd_t is 32-bit aligned");
-
-} /* end DS_CmdReset_Test_Nominal */
+}
 
 void DS_CmdReset_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_ResetCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_RESET_CC;
@@ -208,12 +201,10 @@ void DS_CmdReset_Test_InvalidCommandLength(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end DS_CmdReset_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetAppState_Test_Nominal(void)
 {
-
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "APP STATE command: state = %%d");
@@ -251,12 +242,10 @@ void DS_CmdSetAppState_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_AppStateCmd_t), "DS_AppStateCmd_t is 32-bit aligned");
-
-} /* end DS_CmdSetAppState_Test_Nominal */
+}
 
 void DS_CmdSetAppState_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AppStateCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_APP_STATE_CC;
@@ -288,12 +277,10 @@ void DS_CmdSetAppState_Test_InvalidCommandLength(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end DS_CmdSetAppState_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetAppState_Test_InvalidAppState(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AppStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_APP_STATE_CC;
@@ -324,8 +311,7 @@ void DS_CmdSetAppState_Test_InvalidAppState(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end DS_CmdSetAppState_Test_InvalidAppState */
+}
 
 void DS_CmdSetFilterFile_Test_Nominal(void)
 {
@@ -384,11 +370,10 @@ void DS_CmdSetFilterFile_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterFileCmd_t), "DS_FilterFileCmd_t is 32-bit aligned");
-} /* end DS_CmdSetFilterFile_Test_Nominal */
+}
 
 void DS_CmdSetFilterFile_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterFileCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
@@ -418,12 +403,10 @@ void DS_CmdSetFilterFile_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetFilterFile_Test_InvalidMessageID(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
@@ -455,12 +438,10 @@ void DS_CmdSetFilterFile_Test_InvalidMessageID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_InvalidMessageID */
+}
 
 void DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
@@ -493,12 +474,10 @@ void DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex */
+}
 
 void DS_CmdSetFilterFile_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
@@ -532,12 +511,10 @@ void DS_CmdSetFilterFile_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetFilterFile_Test_FilterTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
@@ -576,8 +553,7 @@ void DS_CmdSetFilterFile_Test_FilterTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_FilterTableNotLoaded */
+}
 
 void DS_CmdSetFilterFile_Test_MessageIDNotInFilterTable(void)
 {
@@ -623,8 +599,7 @@ void DS_CmdSetFilterFile_Test_MessageIDNotInFilterTable(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterFile_Test_MessageIDNotInFilterTable */
+}
 
 void DS_CmdSetFilterType_Test_Nominal(void)
 {
@@ -676,11 +651,10 @@ void DS_CmdSetFilterType_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterTypeCmd_t), "DS_FilterTypeCmd_t is 32-bit aligned");
-} /* end DS_CmdSetFilterType_Test_Nominal */
+}
 
 void DS_CmdSetFilterType_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
@@ -710,12 +684,10 @@ void DS_CmdSetFilterType_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetFilterType_Test_InvalidMessageID(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
@@ -747,12 +719,10 @@ void DS_CmdSetFilterType_Test_InvalidMessageID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_InvalidMessageID */
+}
 
 void DS_CmdSetFilterType_Test_InvalidFilterParametersIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
@@ -784,12 +754,10 @@ void DS_CmdSetFilterType_Test_InvalidFilterParametersIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_InvalidFilterParametersIndex */
+}
 
 void DS_CmdSetFilterType_Test_InvalidFilterType(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
@@ -822,12 +790,10 @@ void DS_CmdSetFilterType_Test_InvalidFilterType(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_InvalidFilterType */
+}
 
 void DS_CmdSetFilterType_Test_FilterTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
@@ -865,8 +831,7 @@ void DS_CmdSetFilterType_Test_FilterTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_FilterTableNotLoaded */
+}
 
 void DS_CmdSetFilterType_Test_MessageIDNotInFilterTable(void)
 {
@@ -912,8 +877,7 @@ void DS_CmdSetFilterType_Test_MessageIDNotInFilterTable(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterType_Test_MessageIDNotInFilterTable */
+}
 
 void DS_CmdSetFilterParms_Test_Nominal(void)
 {
@@ -975,12 +939,10 @@ void DS_CmdSetFilterParms_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterParmsCmd_t), "DS_FilterParmsCmd_t is 32-bit aligned");
-
-} /* end DS_CmdSetFilterParms_Test_Nominal */
+}
 
 void DS_CmdSetFilterParms_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
@@ -1010,12 +972,10 @@ void DS_CmdSetFilterParms_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterParms_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetFilterParms_Test_InvalidMessageID(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
@@ -1047,12 +1007,10 @@ void DS_CmdSetFilterParms_Test_InvalidMessageID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterParms_Test_InvalidMessageID */
+}
 
 void DS_CmdSetFilterParms_Test_InvalidFilterParametersIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
@@ -1085,8 +1043,7 @@ void DS_CmdSetFilterParms_Test_InvalidFilterParametersIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterParms_Test_InvalidFilterParametersIndex */
+}
 
 void DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm(void)
 {
@@ -1131,12 +1088,10 @@ void DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-
-} /* end DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm */
+}
 
 void DS_CmdSetFilterParms_Test_FilterTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
@@ -1174,8 +1129,7 @@ void DS_CmdSetFilterParms_Test_FilterTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterParms_Test_FilterTableNotLoaded */
+}
 
 void DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable(void)
 {
@@ -1220,12 +1174,10 @@ void DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable */
+}
 
 void DS_CmdSetDestType_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
@@ -1267,11 +1219,10 @@ void DS_CmdSetDestType_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestTypeCmd_t), "DS_DestTypeCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestType_Test_Nominal */
+}
 
 void DS_CmdSetDestType_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestTypeCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
@@ -1301,12 +1252,10 @@ void DS_CmdSetDestType_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestType_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestType_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
@@ -1338,12 +1287,10 @@ void DS_CmdSetDestType_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestType_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestType_Test_InvalidFilenameType(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
@@ -1378,12 +1325,10 @@ void DS_CmdSetDestType_Test_InvalidFilenameType(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestType_Test_InvalidFilenameType */
+}
 
 void DS_CmdSetDestType_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
@@ -1421,12 +1366,10 @@ void DS_CmdSetDestType_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestType_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestState_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
@@ -1470,11 +1413,10 @@ void DS_CmdSetDestState_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestStateCmd_t), "DS_DestStateCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestState_Test_Nominal */
+}
 
 void DS_CmdSetDestState_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestStateCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
@@ -1504,12 +1446,10 @@ void DS_CmdSetDestState_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestState_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestState_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
@@ -1541,12 +1481,10 @@ void DS_CmdSetDestState_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestState_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestState_Test_InvalidFileState(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
@@ -1581,12 +1519,10 @@ void DS_CmdSetDestState_Test_InvalidFileState(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestState_Test_InvalidFileState */
+}
 
 void DS_CmdSetDestState_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
@@ -1623,12 +1559,10 @@ void DS_CmdSetDestState_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestState_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestPath_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
@@ -1671,11 +1605,10 @@ void DS_CmdSetDestPath_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestPathCmd_t), "DS_DestPathCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestPath_Test_Nominal */
+}
 
 void DS_CmdSetDestPath_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestPathCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
@@ -1705,12 +1638,10 @@ void DS_CmdSetDestPath_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestPath_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestPath_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
@@ -1742,12 +1673,10 @@ void DS_CmdSetDestPath_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestPath_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestPath_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
@@ -1784,12 +1713,10 @@ void DS_CmdSetDestPath_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestPath_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestBase_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
@@ -1832,11 +1759,10 @@ void DS_CmdSetDestBase_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestBaseCmd_t), "DS_DestBaseCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestBase_Test_Nominal */
+}
 
 void DS_CmdSetDestBase_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestBaseCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
@@ -1866,12 +1792,10 @@ void DS_CmdSetDestBase_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestBase_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestBase_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
@@ -1903,12 +1827,10 @@ void DS_CmdSetDestBase_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestBase_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestBase_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
@@ -1945,12 +1867,10 @@ void DS_CmdSetDestBase_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestBase_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestExt_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
@@ -1994,11 +1914,10 @@ void DS_CmdSetDestExt_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestExtCmd_t), "DS_DestExtCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestExt_Test_Nominal */
+}
 
 void DS_CmdSetDestExt_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestExtCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
@@ -2028,12 +1947,10 @@ void DS_CmdSetDestExt_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestExt_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestExt_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
@@ -2065,12 +1982,10 @@ void DS_CmdSetDestExt_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestExt_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestExt_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
@@ -2107,12 +2022,10 @@ void DS_CmdSetDestExt_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestExt_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestSize_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
@@ -2154,11 +2067,10 @@ void DS_CmdSetDestSize_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestSizeCmd_t), "DS_DestSizeCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestSize_Test_Nominal */
+}
 
 void DS_CmdSetDestSize_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestSizeCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
@@ -2191,12 +2103,10 @@ void DS_CmdSetDestSize_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestSize_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestSize_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
@@ -2229,12 +2139,10 @@ void DS_CmdSetDestSize_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestSize_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestSize_Test_InvalidFileSizeLimit(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
@@ -2271,12 +2179,10 @@ void DS_CmdSetDestSize_Test_InvalidFileSizeLimit(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestSize_Test_InvalidFileSizeLimit */
+}
 
 void DS_CmdSetDestSize_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
@@ -2314,12 +2220,10 @@ void DS_CmdSetDestSize_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestSize_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestAge_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
@@ -2361,11 +2265,10 @@ void DS_CmdSetDestAge_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestAgeCmd_t), "DS_DestAgeCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestAge_Test_Nominal */
+}
 
 void DS_CmdSetDestAge_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestAgeCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
@@ -2398,12 +2301,10 @@ void DS_CmdSetDestAge_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestAge_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestAge_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
@@ -2436,12 +2337,10 @@ void DS_CmdSetDestAge_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestAge_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestAge_Test_InvalidFileAgeLimit(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
@@ -2477,12 +2376,10 @@ void DS_CmdSetDestAge_Test_InvalidFileAgeLimit(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestAge_Test_InvalidFileAgeLimit */
+}
 
 void DS_CmdSetDestAge_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
@@ -2520,12 +2417,10 @@ void DS_CmdSetDestAge_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestAge_Test_FileTableNotLoaded */
+}
 
 void DS_CmdSetDestCount_Test_Nominal(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
@@ -2570,11 +2465,10 @@ void DS_CmdSetDestCount_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestCountCmd_t), "DS_DestCountCmd_t is 32-bit aligned");
-} /* end DS_CmdSetDestCount_Test_Nominal */
+}
 
 void DS_CmdSetDestCount_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestCountCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
@@ -2607,12 +2501,10 @@ void DS_CmdSetDestCount_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestCount_Test_InvalidCommandLength */
+}
 
 void DS_CmdSetDestCount_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
@@ -2645,12 +2537,10 @@ void DS_CmdSetDestCount_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestCount_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdSetDestCount_Test_InvalidFileSequenceCount(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
@@ -2687,12 +2577,10 @@ void DS_CmdSetDestCount_Test_InvalidFileSequenceCount(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestCount_Test_InvalidFileSequenceCount */
+}
 
 void DS_CmdSetDestCount_Test_FileTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
@@ -2730,8 +2618,7 @@ void DS_CmdSetDestCount_Test_FileTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdSetDestCount_Test_FileTableNotLoaded */
+}
 
 void DS_CmdCloseFile_Test_Nominal(void)
 {
@@ -2789,7 +2676,7 @@ void DS_CmdCloseFile_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseFileCmd_t), "DS_CloseFileCmd_t is 32-bit aligned");
-} /* end DS_CmdCloseFile_Test_Nominal */
+}
 
 void DS_CmdCloseFile_Test_NominalAlreadyClosed(void)
 {
@@ -2845,11 +2732,10 @@ void DS_CmdCloseFile_Test_NominalAlreadyClosed(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseFileCmd_t), "DS_CloseFileCmd_t is 32-bit aligned");
-} /* end DS_CmdCloseFile_Test_NominalAlreadyClosed */
+}
 
 void DS_CmdCloseFile_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_CloseFileCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
@@ -2881,12 +2767,10 @@ void DS_CmdCloseFile_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdCloseFile_Test_InvalidCommandLength */
+}
 
 void DS_CmdCloseFile_Test_InvalidFileTableIndex(void)
 {
-
     size_t            forced_Size    = sizeof(DS_CloseFileCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
@@ -2920,8 +2804,7 @@ void DS_CmdCloseFile_Test_InvalidFileTableIndex(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdCloseFile_Test_InvalidFileTableIndex */
+}
 
 void DS_CmdCloseAll_Test_Nominal(void)
 {
@@ -2967,7 +2850,7 @@ void DS_CmdCloseAll_Test_Nominal(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseAllCmd_t), "DS_CloseAllCmd_t is 32-bit aligned");
-} /* end DS_CmdCloseAll_Test_Nominal */
+}
 
 void DS_CmdCloseAll_Test_CloseAll(void)
 {
@@ -2994,12 +2877,10 @@ void DS_CmdCloseAll_Test_CloseAll(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_BOOL_TRUE(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseAllCmd_t));
-
-} /* end DS_CmdCloseAll_Test_CloseAll */
+}
 
 void DS_CmdCloseAll_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_CloseAllCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_ALL_CC;
@@ -3029,8 +2910,7 @@ void DS_CmdCloseAll_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdCloseAll_Test_InvalidCommandLength */
+}
 
 void DS_CmdGetFileInfo_Test_EnabledOpen(void)
 {
@@ -3078,8 +2958,7 @@ void DS_CmdGetFileInfo_Test_EnabledOpen(void)
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(TLM_STRUCT_DATA_IS_32_ALIGNED(DS_FileInfoPkt_t), "DS_FileInfoPkt_t is 32-bit aligned");
-
-} /* end DS_CmdGetFileInfo_Test_EnabledOpen */
+}
 
 void DS_CmdGetFileInfo_Test_DisabledClosed(void)
 {
@@ -3127,12 +3006,10 @@ void DS_CmdGetFileInfo_Test_DisabledClosed(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end DS_CmdGetFileInfo_Test_DisabledClosed */
+}
 
 void DS_CmdGetFileInfo_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_GetFileInfoCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_GET_FILE_INFO_CC;
@@ -3162,8 +3039,7 @@ void DS_CmdGetFileInfo_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdGetFileInfo_Test_InvalidCommandLength */
+}
 
 void DS_CmdAddMID_Test_Nominal(void)
 {
@@ -3259,9 +3135,9 @@ void DS_CmdAddMID_Test_Nominal(void)
     UtAssert_True(DS_AppData.FilterTblPtr->Packet[FilterTableIndex].Filter[DS_FILTERS_PER_PACKET - 1].Algorithm_O == 0,
                   "DS_AppData.FilterTblPtr->Packet[FilterTableIndex].Filter[DS_FILTERS_PER_PACKET-1].Algorithm_O == 0");
 
-    // UtAssert_True (DS_AppData.HashLinks[0].Index == 0, "DS_AppData.HashLinks[0].Index == 0");
-    // UtAssert_True (DS_AppData.HashLinks[0].MessageID == DS_UT_MID_1, "DS_AppData.HashLinks[0].MessageID ==
-    // DS_UT_MID_1");
+    /* UtAssert_True (DS_AppData.HashLinks[0].Index == 0, "DS_AppData.HashLinks[0].Index == 0"); */
+    /* UtAssert_True (DS_AppData.HashLinks[0].MessageID == DS_UT_MID_1, "DS_AppData.HashLinks[0].MessageID ==
+     * DS_UT_MID_1"); */
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -3273,12 +3149,10 @@ void DS_CmdAddMID_Test_Nominal(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_Nominal */
+}
 
 void DS_CmdAddMID_Test_InvalidCommandLength(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AddMidCmd_t) + 1;
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
@@ -3310,12 +3184,10 @@ void DS_CmdAddMID_Test_InvalidCommandLength(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_InvalidCommandLength */
+}
 
 void DS_CmdAddMID_Test_InvalidMessageID(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
@@ -3351,12 +3223,10 @@ void DS_CmdAddMID_Test_InvalidMessageID(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_InvalidMessageID */
+}
 
 void DS_CmdAddMID_Test_FilterTableNotLoaded(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
@@ -3391,8 +3261,7 @@ void DS_CmdAddMID_Test_FilterTableNotLoaded(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_FilterTableNotLoaded */
+}
 
 void DS_CmdAddMID_Test_MIDAlreadyInFilterTable(void)
 {
@@ -3435,12 +3304,10 @@ void DS_CmdAddMID_Test_MIDAlreadyInFilterTable(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_MIDAlreadyInFilterTable */
+}
 
 void DS_CmdAddMID_Test_FilterTableFull(void)
 {
-
     size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
     CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
@@ -3474,8 +3341,7 @@ void DS_CmdAddMID_Test_FilterTableFull(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-} /* end DS_CmdAddMID_Test_FilterTableFull */
+}
 
 void UtTest_Setup(void)
 {
@@ -3639,8 +3505,4 @@ void UtTest_Setup(void)
     UtTest_Add(DS_CmdAddMID_Test_MIDAlreadyInFilterTable, DS_Test_Setup, DS_Test_TearDown,
                "DS_CmdAddMID_Test_MIDAlreadyInFilterTable");
     UtTest_Add(DS_CmdAddMID_Test_FilterTableFull, DS_Test_Setup, DS_Test_TearDown, "DS_CmdAddMID_Test_FilterTableFull");
-} /* end DS_Cmds_Test_AddTestCases */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/ds_file_tests.c
+++ b/unit-test/ds_file_tests.c
@@ -51,6 +51,7 @@ void UT_CFE_TIME_Print_CustomHandler(void *UserObj, UT_EntryKey_t FuncKey, const
 
     snprintf(PrintBuffer, CFE_TIME_PRINTED_STRING_SIZE, "1980-001-00:00.00.00000");
 }
+
 /*
  * Helper Functions
  */
@@ -101,7 +102,7 @@ void DS_FileStorePacket_Test_Nominal(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.PassedPktCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileStorePacket_Test_Nominal */
+}
 
 void DS_FileStorePacket_Test_PacketNotInTable(void)
 {
@@ -129,8 +130,7 @@ void DS_FileStorePacket_Test_PacketNotInTable(void)
     /* Verify results */
     UtAssert_INT32_EQ(DS_AppData.IgnoredPktCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileStorePacket_Test_PacketNotInTable */
+}
 
 void DS_FileStorePacket_Test_PassedFilterFalse(void)
 {
@@ -163,8 +163,7 @@ void DS_FileStorePacket_Test_PassedFilterFalse(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileStorePacket_Test_PassedFilterFalse */
+}
 
 void DS_FileStorePacket_Test_DisabledDest(void)
 {
@@ -195,8 +194,7 @@ void DS_FileStorePacket_Test_DisabledDest(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileStorePacket_Test_DisabledDest */
+}
 
 void DS_FileStorePacket_Test_InvalidIndex(void)
 {
@@ -228,8 +226,7 @@ void DS_FileStorePacket_Test_InvalidIndex(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileStorePacket_Test_InvalidIndex */
+}
 
 void DS_FileSetupWrite_Test_Nominal(void)
 {
@@ -252,8 +249,7 @@ void DS_FileSetupWrite_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileSetupWrite_Test_Nominal */
+}
 
 void DS_FileSetupWrite_Test_FileHandleClosed(void)
 {
@@ -283,7 +279,7 @@ void DS_FileSetupWrite_Test_FileHandleClosed(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1); /* Don't care about subroutine event */
     UtAssert_STUB_COUNT(OS_write, 0);
     UtAssert_STUB_COUNT(OS_OpenCreate, 1);
-} /* end DS_FileSetupWrite_Test_FileHandleClosed */
+}
 
 void DS_FileSetupWrite_Test_MaxFileSizeExceeded(void)
 {
@@ -312,8 +308,7 @@ void DS_FileSetupWrite_Test_MaxFileSizeExceeded(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileSetupWrite_Test_MaxFileSizeExceeded */
+}
 
 void DS_FileWriteData_Test_Nominal(void)
 {
@@ -335,8 +330,7 @@ void DS_FileWriteData_Test_Nominal(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileGrowth, sizeof(UT_CmdBuf.Buf));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileWriteData_Test_Nominal */
+}
 
 void DS_FileWriteData_Test_Error(void)
 {
@@ -368,8 +362,7 @@ void DS_FileWriteData_Test_Error(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_WRITE_FILE_ERR_EID);
-
-} /* end DS_FileWriteData_Test_Error */
+}
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
 void DS_FileWriteHeader_Test_PlatformConfigCFE_Nominal(void)
@@ -387,8 +380,7 @@ void DS_FileWriteHeader_Test_PlatformConfigCFE_Nominal(void)
     UtAssert_UINT32_EQ(DS_AppData.FileWriteCounter, 2);
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileSize, sizeof(CFE_FS_Header_t) + sizeof(DS_FileHeader_t));
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileGrowth, sizeof(CFE_FS_Header_t) + sizeof(DS_FileHeader_t));
-
-} /* end DS_FileWriteHeader_Test_PlatformConfigCFE_Nominal */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -410,8 +402,7 @@ void DS_FileWriteHeader_Test_PrimaryHeaderError(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end DS_FileWriteHeader_Test_PrimaryHeaderError */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -435,8 +426,7 @@ void DS_FileWriteHeader_Test_SecondaryHeaderError(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
-
-} /* end DS_FileWriteHeader_Test_SecondaryHeaderError */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -463,8 +453,7 @@ void DS_FileWriteError_Test(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_WRITE_FILE_ERR_EID);
-
-} /* end DS_FileWriteError_Test */
+}
 #endif
 
 void DS_FileCreateDest_Test_Nominal(void)
@@ -500,8 +489,7 @@ void DS_FileCreateDest_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(DS_TableUpdateCDS, 1);
-
-} /* end DS_FileCreateDest_Test_Nominal */
+}
 
 void DS_FileCreateDest_Test_StringTerminate(void)
 {
@@ -512,8 +500,7 @@ void DS_FileCreateDest_Test_StringTerminate(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(OS_OpenCreate, 0);
-
-} /* end DS_FileCreateDest_Test_StringTerminate */
+}
 
 void DS_FileCreateDest_Test_NominalRollover(void)
 {
@@ -548,8 +535,7 @@ void DS_FileCreateDest_Test_NominalRollover(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(DS_TableUpdateCDS, 1);
-
-} /* end DS_FileCreateDest_Test_NominalRollover */
+}
 
 void DS_FileCreateDest_Test_Error(void)
 {
@@ -574,8 +560,7 @@ void DS_FileCreateDest_Test_Error(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_CREATE_FILE_ERR_EID);
-
-} /* end DS_FileCreateDest_Test_Error */
+}
 
 void DS_FileCreateDest_Test_ClosedFileHandle(void)
 {
@@ -602,8 +587,7 @@ void DS_FileCreateDest_Test_ClosedFileHandle(void)
     UtAssert_BOOL_FALSE(OS_ObjectIdDefined(DS_AppData.FileStatus[FileIndex].FileHandle));
     UtAssert_INT32_EQ(DS_AppData.FileStatus[FileIndex].FileCount, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end DS_FileCreateDest_Test_ClosedFileHandle */
+}
 
 void DS_FileCreateName_Test_Nominal(void)
 {
@@ -623,8 +607,7 @@ void DS_FileCreateName_Test_Nominal(void)
                           StrCompare, sizeof(StrCompare));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateName_Test_Nominal */
+}
 
 void DS_FileCreateName_Test_NominalWithSeparator(void)
 {
@@ -646,8 +629,7 @@ void DS_FileCreateName_Test_NominalWithSeparator(void)
                           StrCompare, sizeof(StrCompare));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateName_Test_NominalWithSeparator */
+}
 
 void DS_FileCreateName_Test_NominalWithPeriod(void)
 {
@@ -669,8 +651,7 @@ void DS_FileCreateName_Test_NominalWithPeriod(void)
                           StrCompare, sizeof(StrCompare));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateName_Test_NominalWithPeriod */
+}
 
 void DS_FileCreateName_Test_EmptyPath(void)
 {
@@ -690,8 +671,7 @@ void DS_FileCreateName_Test_EmptyPath(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FILE_CREATE_EMPTY_PATH_ERR_EID);
-
-} /* end DS_FileCreateName_Test_EmptyPath */
+}
 
 void DS_FileCreateName_Test_Error(void)
 {
@@ -716,8 +696,7 @@ void DS_FileCreateName_Test_Error(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FILE_NAME_ERR_EID);
-
-} /* end DS_FileCreateName_Test_Error */
+}
 
 void DS_FileCreateName_Test_PathBaseSeqTooLarge(void)
 {
@@ -743,8 +722,7 @@ void DS_FileCreateName_Test_PathBaseSeqTooLarge(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FILE_NAME_ERR_EID);
-
-} /* end DS_FileCreateName_Test_PathBaseSeqTooLarge */
+}
 
 void DS_FileCreateName_Test_PathBaseSeqExtTooLarge(void)
 {
@@ -773,8 +751,7 @@ void DS_FileCreateName_Test_PathBaseSeqExtTooLarge(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FILE_NAME_ERR_EID);
-
-} /* end DS_FileCreateName_Test_PathBaseSeqExtTooLarge */
+}
 
 void DS_FileCreateName_Test_ExtensionZero(void)
 {
@@ -796,8 +773,7 @@ void DS_FileCreateName_Test_ExtensionZero(void)
     UtAssert_STRINGBUF_EQ(DS_AppData.FileStatus[FileIndex].FileName, sizeof(DS_AppData.FileStatus[FileIndex].FileName),
                           StrCompare, sizeof(StrCompare));
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateName_Test_ExtensionZero */
+}
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
 void DS_FileCreateSequence_Test_ByCount(void)
@@ -819,8 +795,7 @@ void DS_FileCreateSequence_Test_ByCount(void)
     /* Verify results */
     UtAssert_UINT32_EQ(strncmp(Sequence, "00000001", DS_TOTAL_FNAME_BUFSIZE), 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateSequence_Test_ByCount */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -849,8 +824,7 @@ void DS_FileCreateSequence_Test_ByTime(void)
     UtAssert_INT32_EQ(strncmp(Sequence, "1980001000000", DS_TOTAL_FNAME_BUFSIZE), 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCreateSequence_Test_ByTime */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -872,7 +846,7 @@ void DS_FileCreateSequence_Test_BadFilenameType(void)
     /* Verify results */
     UtAssert_UINT32_EQ(strncmp(Sequence, "", DS_TOTAL_FNAME_BUFSIZE), 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileCreateSequence_Test_BadFilenameType */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -886,7 +860,7 @@ void DS_FileUpdateHeader_Test_PlatformConfigCFE_Nominal(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileUpdateHeader_Test_PlatformConfigCFE_Nominal */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -903,7 +877,7 @@ void DS_FileUpdateHeader_Test_WriteError(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileUpdateHeader_Test_WriteError */
+}
 #endif
 
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -920,8 +894,7 @@ void DS_FileUpdateHeader_Test_PlatformConfigCFE_SeekError(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileUpdateHeader_Test_PlatformConfigCFE_SeekError */
+}
 #endif
 
 #if (DS_MOVE_FILES == true)
@@ -946,8 +919,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_Nominal(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileSize, 0);
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileName[0], 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileCloseDest_Test_PlatformConfigMoveFiles_Nominal */
+}
 #endif
 
 #if (DS_MOVE_FILES == true)
@@ -975,8 +947,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_MoveError(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_MOVE_FILE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end DS_FileCloseDest_Test_PlatformConfigMoveFiles_MoveError */
+}
 #endif
 
 #if (DS_MOVE_FILES == true)
@@ -1001,8 +972,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_FilenameTooLarge(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_MOVE_FILE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end DS_FileCloseDest_Test_PlatformConfigMoveFiles_FilenameTooLarge */
+}
 #endif
 
 #if (DS_MOVE_FILES == true)
@@ -1027,8 +997,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_FilenameNull(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_MOVE_FILE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
-} /* end DS_FileCloseDest_Test_PlatformConfigMoveFiles_Null */
+}
 #endif
 
 #if (DS_MOVE_FILES == false)
@@ -1048,7 +1017,7 @@ void DS_FileCloseDest_Test_MoveFilesFalse(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileSize, 0);
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileName[0], 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileCloseDest_Test_MoveFilesFalse */
+}
 #endif
 
 void DS_FileTestAge_Test_Nominal(void)
@@ -1074,7 +1043,7 @@ void DS_FileTestAge_Test_Nominal(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 2);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileTestAge_Test_Nominal */
+}
 
 void DS_FileTestAge_Test_NullTable(void)
 {
@@ -1087,8 +1056,7 @@ void DS_FileTestAge_Test_NullTable(void)
     /* Verify results */
     UtAssert_STUB_COUNT(OS_close, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_FileTestAge_Test_NullTable */
+}
 
 void DS_FileTestAge_Test_ExceedMaxAge(void)
 {
@@ -1106,7 +1074,7 @@ void DS_FileTestAge_Test_ExceedMaxAge(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 0);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_FileTestAge_Test_ExceedMaxAge */
+}
 
 void DS_IsPacketFiltered_Test_AlgX0(void)
 {
@@ -1412,9 +1380,4 @@ void UtTest_Setup(void)
 
     UT_DS_TEST_ADD(DS_FileTransmit_Test_Nominal);
     UT_DS_TEST_ADD(DS_FileTransmit_Test_NoBuf);
-
-} /* end DS_File_Test_AddTestCases */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/ds_table_tests.c
+++ b/unit-test/ds_table_tests.c
@@ -57,7 +57,7 @@ void DS_TableInit_Test_Nominal(void)
     UtAssert_INT32_EQ(DS_TableInit(), CFE_SUCCESS);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end DS_TableInit_Test_Nominal */
+}
 
 void DS_TableInit_Test_TableInfoRecovered(void)
 {
@@ -76,8 +76,7 @@ void DS_TableInit_Test_TableInfoRecovered(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_INIT_TBL_CDS_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
-
-} /* end DS_TableInit_Test_TableInfoRecovered */
+}
 
 void DS_TableInit_Test_RegisterDestTableError(void)
 {
@@ -94,8 +93,7 @@ void DS_TableInit_Test_RegisterDestTableError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableInit_Test_RegisterDestTableError */
+}
 
 void DS_TableInit_Test_RegisterFilterTableError(void)
 {
@@ -112,8 +110,7 @@ void DS_TableInit_Test_RegisterFilterTableError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableInit_Test_RegisterFilterTableError */
+}
 
 void DS_TableInit_Test_LoadDestTableError(void)
 {
@@ -127,8 +124,7 @@ void DS_TableInit_Test_LoadDestTableError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableInit_Test_LoadDestTableError */
+}
 
 void DS_TableInit_Test_LoadFilterTableError(void)
 {
@@ -146,8 +142,7 @@ void DS_TableInit_Test_LoadFilterTableError(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableInit_Test_LoadFilterTableError */
+}
 
 void DS_TableManageDestFile_Test_TableInfoUpdated(void)
 {
@@ -180,8 +175,7 @@ void DS_TableManageDestFile_Test_TableInfoUpdated(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[DS_DEST_FILE_CNT - 1].FileCount, DS_DEST_FILE_CNT - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableInfoUpdated */
+}
 
 void DS_TableManageDestFile_Test_TableNeverLoaded(void)
 {
@@ -196,8 +190,7 @@ void DS_TableManageDestFile_Test_TableNeverLoaded(void)
     UtAssert_ADDRESS_EQ(DS_AppData.DestFileTblPtr, NULL);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableNeverLoaded */
+}
 
 void DS_TableManageDestFile_Test_TableInfoDumpPending(void)
 {
@@ -209,8 +202,7 @@ void DS_TableManageDestFile_Test_TableInfoDumpPending(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableInfoDumpPending */
+}
 
 void DS_TableManageDestFile_Test_TableInfoValidationPending(void)
 {
@@ -222,8 +214,7 @@ void DS_TableManageDestFile_Test_TableInfoValidationPending(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableInfoValidationPending */
+}
 
 void DS_TableManageDestFile_Test_TableInfoUpdatePending(void)
 {
@@ -254,8 +245,7 @@ void DS_TableManageDestFile_Test_TableInfoUpdatePending(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[DS_DEST_FILE_CNT - 1].FileCount, DS_DEST_FILE_CNT - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableInfoUpdatePending */
+}
 
 void DS_TableManageDestFile_Test_TableSuccess(void)
 {
@@ -286,8 +276,7 @@ void DS_TableManageDestFile_Test_TableSuccess(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[DS_DEST_FILE_CNT - 1].FileCount, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageDestFile_Test_TableInfoUpdatePending */
+}
 
 void DS_TableManageFilter_Test_TableInfoUpdated(void)
 {
@@ -303,8 +292,7 @@ void DS_TableManageFilter_Test_TableInfoUpdated(void)
     UtAssert_UINT32_EQ(DS_AppData.FilterTblLoadCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableInfoUpdated */
+}
 
 void DS_TableManageFilter_Test_TableNeverLoaded(void)
 {
@@ -320,8 +308,7 @@ void DS_TableManageFilter_Test_TableNeverLoaded(void)
     UtAssert_ADDRESS_EQ(DS_AppData.FilterTblPtr, NULL);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableNeverLoaded */
+}
 
 void DS_TableManageFilter_Test_TableInfoDumpPending(void)
 {
@@ -333,8 +320,7 @@ void DS_TableManageFilter_Test_TableInfoDumpPending(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableInfoDumpPending */
+}
 
 void DS_TableManageFilter_Test_TableInfoValidationPending(void)
 {
@@ -346,12 +332,10 @@ void DS_TableManageFilter_Test_TableInfoValidationPending(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableInfoValidationPending */
+}
 
 void DS_TableManageFilter_Test_TableInfoUpdatePending(void)
 {
-
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetStatus), CFE_TBL_INFO_UPDATE_PENDING);
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
@@ -362,12 +346,10 @@ void DS_TableManageFilter_Test_TableInfoUpdatePending(void)
     UtAssert_UINT32_EQ(DS_AppData.FilterTblLoadCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableInfoUpdatePending */
+}
 
 void DS_TableManageFilter_Test_TableSuccess(void)
 {
-
     /* Returns CFE_TBL_INFO_UPDATED to satisfy condition "if (Result == CFE_TBL_INFO_UPDATE_PENDING)", and sets
      * DS_AppData.DestFileTblPtr to the address of a local table defined globally in this file, to prevent segmentation
      * fault */
@@ -381,8 +363,7 @@ void DS_TableManageFilter_Test_TableSuccess(void)
     UtAssert_UINT32_EQ(DS_AppData.FilterTblLoadCounter, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableManageFilter_Test_TableInfoUpdatePending */
+}
 
 void DS_TableVerifyDestFile_Test_Nominal(void)
 {
@@ -407,8 +388,7 @@ void DS_TableVerifyDestFile_Test_Nominal(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyDestFile_Test_Nominal */
+}
 
 void DS_TableVerifyDestFile_Test_DestFileTableVerificationError(void)
 {
@@ -442,8 +422,7 @@ void DS_TableVerifyDestFile_Test_DestFileTableVerificationError(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_FIL_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyDestFile_Test_DestFileTableVerificationError */
+}
 
 void DS_TableVerifyDestFile_Test_CountBad(void)
 {
@@ -473,8 +452,7 @@ void DS_TableVerifyDestFile_Test_CountBad(void)
     /* this generates 1 event message we don't care about for this test */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_FIL_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyDestFile_Test_CountBad */
+}
 
 void DS_TableVerifyDestFileEntry_Test_NominalErrZero(void)
 {
@@ -497,8 +475,7 @@ void DS_TableVerifyDestFileEntry_Test_NominalErrZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_NominalErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidPathnameErrZero(void)
 {
@@ -523,8 +500,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidPathnameErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidPathnameErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidBasenameErrZero(void)
 {
@@ -549,8 +525,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidBasenameErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidBasenameErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrZero(void)
 {
@@ -575,8 +550,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrZero(void)
 {
@@ -601,8 +575,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidSizeErrZero(void)
 {
@@ -627,8 +600,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidSizeErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidSizeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidAgeErrZero(void)
 {
@@ -653,8 +625,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidAgeErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidAgeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrZero(void)
 {
@@ -679,8 +650,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FIL_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrNonZero(void)
 {
@@ -703,8 +673,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidFilenameTypeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrNonZero(void)
 {
@@ -727,8 +696,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidFileEnableStateErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidSizeErrNonZero(void)
 {
@@ -751,8 +719,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidSizeErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidSizeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidAgeErrNonZero(void)
 {
@@ -775,8 +742,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidAgeErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidAgeErrZero */
+}
 
 void DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrNonZero(void)
 {
@@ -799,8 +765,7 @@ void DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyDestFileEntry_Test_InvalidSequenceCountErrZero */
+}
 
 void DS_TableVerifyFilter_Test_Nominal(void)
 {
@@ -831,8 +796,7 @@ void DS_TableVerifyFilter_Test_Nominal(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FLT_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyFilter_Test_Nominal */
+}
 
 void DS_TableVerifyFilter_Test_FilterTableVerificationError(void)
 {
@@ -869,8 +833,7 @@ void DS_TableVerifyFilter_Test_FilterTableVerificationError(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_FLT_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyFilter_Test_FilterTableVerificationError */
+}
 
 void DS_TableVerifyFilter_Test_CountBad(void)
 {
@@ -902,8 +865,7 @@ void DS_TableVerifyFilter_Test_CountBad(void)
     /* this generates 1 event message we don't care about for this test */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_FLT_TBL_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
-
-} /* end DS_TableVerifyFilter_Test_CountBad */
+}
 
 void DS_TableVerifyFilterEntry_Test_Unused(void)
 {
@@ -926,8 +888,7 @@ void DS_TableVerifyFilterEntry_Test_Unused(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFilterEntry_Test_Unused */
+}
 
 void DS_TableVerifyFilterEntry_Test_Nominal(void)
 {
@@ -950,8 +911,7 @@ void DS_TableVerifyFilterEntry_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFilterEntry_Test_Nominal */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrZero(void)
 {
@@ -976,8 +936,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FLT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrZero */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrZero(void)
 {
@@ -1002,8 +961,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FLT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrZero */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrZero(void)
 {
@@ -1028,8 +986,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrZero(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FLT_TBL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrZero */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrNonZero(void)
 {
@@ -1052,8 +1009,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFileTableIndexErrNonZero */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrNonZero(void)
 {
@@ -1076,8 +1032,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFilterTypeErrNonZero */
+}
 
 void DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrNonZero(void)
 {
@@ -1100,8 +1055,7 @@ void DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFilterEntry_Test_InvalidFilterParmsErrNonZero */
+}
 
 void DS_TableEntryUnused_Test_Nominal(void)
 {
@@ -1114,8 +1068,7 @@ void DS_TableEntryUnused_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableEntryUnused_Test_Nominal */
+}
 
 void DS_TableEntryUnused_Test_Fail(void)
 {
@@ -1128,8 +1081,7 @@ void DS_TableEntryUnused_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableEntryUnused_Test_Fail */
+}
 
 void DS_TableVerifyFileIndex_Test_Nominal(void)
 {
@@ -1140,8 +1092,7 @@ void DS_TableVerifyFileIndex_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFileIndex_Test_Nominal */
+}
 
 void DS_TableVerifyFileIndex_Test_Fail(void)
 {
@@ -1152,8 +1103,7 @@ void DS_TableVerifyFileIndex_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyFileIndex_Test_Fail */
+}
 
 void DS_TableVerifyParms_Test_NominalOnlyXNonZero(void)
 {
@@ -1166,8 +1116,7 @@ void DS_TableVerifyParms_Test_NominalOnlyXNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyParms_Test_NominalOnlyXNonZero */
+}
 
 void DS_TableVerifyParms_Test_NGreaterThanXOnlyNNonZero(void)
 {
@@ -1180,8 +1129,7 @@ void DS_TableVerifyParms_Test_NGreaterThanXOnlyNNonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyParms_Test_NGreaterThanXOnlyNNonZero */
+}
 
 void DS_TableVerifyParms_Test_OGreaterThanXOnlyONonZero(void)
 {
@@ -1194,8 +1142,7 @@ void DS_TableVerifyParms_Test_OGreaterThanXOnlyONonZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyParms_Test_OGreaterThanXOnlyONonZero */
+}
 
 void DS_TableVerifyParms_Test_AllZero(void)
 {
@@ -1208,8 +1155,7 @@ void DS_TableVerifyParms_Test_AllZero(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyParms_Test_AllZero */
+}
 
 void DS_TableVerifyType_Test_Nominal(void)
 {
@@ -1220,8 +1166,7 @@ void DS_TableVerifyType_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyType_Test_Nominal */
+}
 
 void DS_TableVerifyType_Test_Fail(void)
 {
@@ -1232,8 +1177,7 @@ void DS_TableVerifyType_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyType_Test_Fail */
+}
 
 void DS_TableVerifyState_Test_NominalEnabled(void)
 {
@@ -1244,8 +1188,7 @@ void DS_TableVerifyState_Test_NominalEnabled(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyState_Test_NominalEnabled */
+}
 
 void DS_TableVerifyState_Test_NominalDisabled(void)
 {
@@ -1256,8 +1199,7 @@ void DS_TableVerifyState_Test_NominalDisabled(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyState_Test_NominalDisabled */
+}
 
 void DS_TableVerifyState_Test_Fail(void)
 {
@@ -1268,8 +1210,7 @@ void DS_TableVerifyState_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyState_Test_Fail */
+}
 
 void DS_TableVerifySize_Test_Nominal(void)
 {
@@ -1280,8 +1221,7 @@ void DS_TableVerifySize_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifySize_Test_Nominal */
+}
 
 void DS_TableVerifySize_Test_Fail(void)
 {
@@ -1292,8 +1232,7 @@ void DS_TableVerifySize_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifySize_Test_Fail */
+}
 
 void DS_TableVerifyAge_Test_Nominal(void)
 {
@@ -1304,8 +1243,7 @@ void DS_TableVerifyAge_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyAge_Test_Nominal */
+}
 
 void DS_TableVerifyAge_Test_Fail(void)
 {
@@ -1316,8 +1254,7 @@ void DS_TableVerifyAge_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyAge_Test_Fail */
+}
 
 void DS_TableVerifyCount_Test_Nominal(void)
 {
@@ -1328,8 +1265,7 @@ void DS_TableVerifyCount_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyCount_Test_Nominal */
+}
 
 void DS_TableVerifyCount_Test_Fail(void)
 {
@@ -1340,20 +1276,17 @@ void DS_TableVerifyCount_Test_Fail(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableVerifyCount_Test_Fail */
+}
 
 void DS_TableSubscribe_Test_Unused(void)
 {
-
     /* Execute the function being tested */
     DS_TableSubscribe();
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_SubscribeEx, 0);
-
-} /* end DS_TableSubscribe_Test_Unused */
+}
 
 void DS_TableSubscribe_Test_Cmd(void)
 {
@@ -1365,8 +1298,7 @@ void DS_TableSubscribe_Test_Cmd(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_SubscribeEx, 0);
-
-} /* end DS_TableSubscribe_Test_Cmd */
+}
 
 void DS_TableSubscribe_Test_SendHk(void)
 {
@@ -1378,8 +1310,7 @@ void DS_TableSubscribe_Test_SendHk(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_SubscribeEx, 0);
-
-} /* end DS_TableSubscribe_Test_SendHk*/
+}
 
 void DS_TableSubscribe_Test_Data(void)
 {
@@ -1391,8 +1322,7 @@ void DS_TableSubscribe_Test_Data(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_SubscribeEx, 1);
-
-} /* end DS_TableSubscribe_Test_Data */
+}
 
 void DS_TableUnsubscribe_Test_Unused(void)
 {
@@ -1402,8 +1332,7 @@ void DS_TableUnsubscribe_Test_Unused(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_Unsubscribe, 0);
-
-} /* end DS_TableUnsubscribe_Test_Unused */
+}
 
 void DS_TableUnsubscribe_Test_Cmd(void)
 {
@@ -1415,8 +1344,7 @@ void DS_TableUnsubscribe_Test_Cmd(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_Unsubscribe, 0);
-
-} /* end DS_TableUnsubscribe_Test_Cmd */
+}
 
 void DS_TableUnsubscribe_Test_SendHk(void)
 {
@@ -1428,8 +1356,7 @@ void DS_TableUnsubscribe_Test_SendHk(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_Unsubscribe, 0);
-
-} /* end DS_TableUnsubscribe_Test_SendHk */
+}
 
 void DS_TableUnsubscribe_Test_Data(void)
 {
@@ -1441,8 +1368,7 @@ void DS_TableUnsubscribe_Test_Data(void)
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
     UtAssert_STUB_COUNT(CFE_SB_Unsubscribe, 1);
-
-} /* end DS_TableUnsubscribe_Test_Data */
+}
 
 void DS_TableCreateCDS_Test_NewCDSArea(void)
 {
@@ -1451,8 +1377,7 @@ void DS_TableCreateCDS_Test_NewCDSArea(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableCreateCDS_Test_NewCDSArea */
+}
 
 void DS_TableCreateCDS_Test_PreExistingCDSArea(void)
 {
@@ -1475,8 +1400,7 @@ void DS_TableCreateCDS_Test_PreExistingCDSArea(void)
 #endif
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableCreateCDS_Test_PreExistingCDSArea */
+}
 
 void DS_TableCreateCDS_Test_RestoreFail(void)
 {
@@ -1494,8 +1418,7 @@ void DS_TableCreateCDS_Test_RestoreFail(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_CDS_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableCreateCDS_Test_RestoreFail */
+}
 
 void DS_TableCreateCDS_Test_Error(void)
 {
@@ -1511,8 +1434,7 @@ void DS_TableCreateCDS_Test_Error(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_CDS_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableCreateCDS_Test_Error */
+}
 
 void DS_TableUpdateCDS_Test_Nominal(void)
 {
@@ -1523,8 +1445,7 @@ void DS_TableUpdateCDS_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableUpdateCDS_Test_Nominal */
+}
 
 void DS_TableUpdateCDS_Test_Error(void)
 {
@@ -1540,8 +1461,7 @@ void DS_TableUpdateCDS_Test_Error(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_CDS_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-} /* end DS_TableUpdateCDS_Test_Error */
+}
 
 void DS_TableHashFunction_Test(void)
 {
@@ -1551,8 +1471,7 @@ void DS_TableHashFunction_Test(void)
     UtAssert_UINT32_LT(DS_TableHashFunction(MessageID), DS_HASH_TABLE_ENTRIES);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableHashFunction_Test */
+}
 
 void DS_TableCreateHash_Test_Nominal(void)
 {
@@ -1570,8 +1489,7 @@ void DS_TableCreateHash_Test_Nominal(void)
     UtAssert_ADDRESS_EQ(DS_AppData.HashTable[HashIndex], &DS_AppData.HashLinks[0]);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableCreateHash_Test_Nominal */
+}
 
 void DS_TableFindMsgID_Test(void)
 {
@@ -1589,8 +1507,7 @@ void DS_TableFindMsgID_Test(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableFindMsgID_Test */
+}
 
 void DS_TableFindMsgID_Test_NullTable(void)
 {
@@ -1606,8 +1523,7 @@ void DS_TableFindMsgID_Test_NullTable(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableFindMsgID_Test_NullTable */
+}
 
 void DS_TableFindMsgID_Test_Mismatch(void)
 {
@@ -1628,8 +1544,7 @@ void DS_TableFindMsgID_Test_Mismatch(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
-} /* end DS_TableFindMsgID_Test_Mismatch */
+}
 
 void UtTest_Setup(void)
 {
@@ -1736,8 +1651,4 @@ void UtTest_Setup(void)
     UT_DS_TEST_ADD(DS_TableFindMsgID_Test_NullTable);
 
     UT_DS_TEST_ADD(DS_TableFindMsgID_Test_Mismatch);
-} /* end DS_Table_Test_AddTestCases */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/ds_app_stubs.c
+++ b/unit-test/stubs/ds_app_stubs.c
@@ -50,7 +50,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppData -- application global data structure                 */
+/* Application global data structure                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -58,29 +58,29 @@ DS_AppData_t DS_AppData;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppMain() -- application entry point and main process loop   */
+/* Application entry point and main process loop                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_AppMain(void)
 {
     UT_DEFAULT_IMPL(DS_AppMain);
-} /* End of DS_AppMain() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppInitialize() -- application initialization                */
+/* Application initialization                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 DS_AppInitialize(void)
 {
     return UT_DEFAULT_IMPL(DS_AppInitialize);
-} /* End of DS_AppInitialize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessMsg() -- process Software Bus messages             */
+/* Process Software Bus messages                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -88,12 +88,11 @@ void DS_AppProcessMsg(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppProcessMsg), BufPtr);
     UT_DEFAULT_IMPL(DS_AppProcessMsg);
-
-} /* End of DS_AppProcessMsg() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessCmd() -- process application commands              */
+/* Process application commands                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -101,23 +100,22 @@ void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppProcessCmd), BufPtr);
     UT_DEFAULT_IMPL(DS_AppProcessCmd);
-
-} /* End of DS_AppProcessCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppProcessHK() -- process hk request command                 */
+/* Process hk request command                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_AppProcessHK(void)
 {
     UT_DEFAULT_IMPL(DS_AppProcessHK);
-} /* End of DS_AppProcessHK() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_AppStorePacket() -- packet storage pre-processor             */
+/* Packet storage pre-processor                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -126,9 +124,4 @@ void DS_AppStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppStorePacket), MessageID);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppStorePacket), BufPtr);
     UT_DEFAULT_IMPL(DS_AppStorePacket);
-
-} /* End of DS_AppStorePacket() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/ds_cmds_stubs.c
+++ b/unit-test/stubs/ds_cmds_stubs.c
@@ -47,7 +47,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdNoop() - NOOP command                                     */
+/* NOOP command                                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -55,12 +55,11 @@ void DS_CmdNoop(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdNoop), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdNoop);
-
-} /* End of DS_CmdNoop() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdReset() - reset hk telemetry counters command             */
+/* Reset hk telemetry counters command                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -68,12 +67,11 @@ void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdReset), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdReset);
-
-} /* End of DS_CmdReset() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetAppState() - set application ena/dis state             */
+/* Set application ena/dis state                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -81,12 +79,11 @@ void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetAppState), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetAppState);
-
-} /* End of DS_CmdSetAppState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterFile() - set packet filter file index            */
+/* Set packet filter file index                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -94,12 +91,11 @@ void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterFile), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetFilterFile);
-
-} /* End of DS_CmdSetFilterFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterType() - set pkt filter filename type            */
+/* Set pkt filter filename type                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -107,12 +103,11 @@ void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterType), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetFilterType);
-
-} /* End of DS_CmdSetFilterType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetFilterParms() - set packet filter parameters           */
+/* Set packet filter parameters                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -120,12 +115,11 @@ void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterParms), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetFilterParms);
-
-} /* End of DS_CmdSetFilterParms() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestType() - set destination filename type             */
+/* Set destination filename type                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -133,12 +127,11 @@ void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestType), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestType);
-
-} /* End of DS_CmdSetDestType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestState() - set dest file ena/dis state              */
+/* Set dest file ena/dis state                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -146,12 +139,11 @@ void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestState), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestState);
-
-} /* End of DS_CmdSetDestState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestPath() - set path portion of filename              */
+/* Set path portion of filename                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -159,12 +151,11 @@ void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestPath), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestPath);
-
-} /* End of DS_CmdSetDestPath() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestBase() - set base portion of filename              */
+/* Set base portion of filename                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -172,12 +163,11 @@ void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestBase), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestBase);
-
-} /* End of DS_CmdSetDestBase() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestExt() - set extension portion of filename          */
+/* Set extension portion of filename                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -185,12 +175,11 @@ void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestExt), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestExt);
-
-} /* End of DS_CmdSetDestExt() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestSize() - set maximum file size limit               */
+/* Set maximum file size limit                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -198,12 +187,11 @@ void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestSize), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestSize);
-
-} /* End of DS_CmdSetDestSize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestAge() - set maximum file age limit                 */
+/* Set maximum file age limit                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -211,12 +199,11 @@ void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestAge), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestAge);
-
-} /* End of DS_CmdSetDestAge() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdSetDestCount() - set seq cnt portion of filename          */
+/* Set seq cnt portion of filename                                 */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -224,12 +211,11 @@ void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestCount), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdSetDestCount);
-
-} /* End of DS_CmdSetDestCount() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdCloseFile() - close destination file                      */
+/* Close destination file                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -237,12 +223,11 @@ void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdCloseFile), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdCloseFile);
-
-} /* End of DS_CmdCloseFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdCloseAll() - close all open destination files             */
+/* Close all open destination files                                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -250,12 +235,11 @@ void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdCloseAll), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdCloseAll);
-
-} /* End of DS_CmdCloseAll() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdGetFileInfo() - get file info packet                      */
+/* Get file info packet                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -263,12 +247,11 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdGetFileInfo), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdGetFileInfo);
-
-} /* End of DS_CmdGetFileInfo() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_CmdAddMID() - add message ID to packet filter table          */
+/* Add message ID to packet filter table                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -276,9 +259,4 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdAddMID), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdAddMID);
-
-} /* End of DS_CmdAddMID() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/ds_file_stubs.c
+++ b/unit-test/stubs/ds_file_stubs.c
@@ -45,7 +45,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileStorePacket() - store packet in file(s)                  */
+/* Store packet in file(s)                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -54,11 +54,11 @@ void DS_FileStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileStorePacket), MessageID);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileStorePacket), BufPtr);
     UT_DEFAULT_IMPL(DS_FileStorePacket);
-} /* End of DS_FileStorePacket() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileSetupWrite() - prepare to write packet data to file      */
+/* Prepare to write packet data to file                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -67,12 +67,11 @@ void DS_FileSetupWrite(int32 FileIndex, const CFE_SB_Buffer_t *BufPtr)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileSetupWrite), FileIndex);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileSetupWrite), BufPtr);
     UT_DEFAULT_IMPL(DS_FileSetupWrite);
-
-} /* End of DS_FileSetupWrite() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteData() - write data to destination file             */
+/* Write data to destination file                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -82,12 +81,11 @@ void DS_FileWriteData(int32 FileIndex, const void *FileData, uint32 DataLength)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteData), FileData);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteData), DataLength);
     UT_DEFAULT_IMPL(DS_FileWriteData);
-
-} /* End of DS_FileWriteData() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteHeader() - write header to destination file         */
+/* Write header to destination file                                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -95,12 +93,11 @@ void DS_FileWriteHeader(int32 FileIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteHeader), FileIndex);
     UT_DEFAULT_IMPL(DS_FileWriteHeader);
-
-} /* End of DS_FileWriteHeader() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileWriteError() - file write error handler                  */
+/* File write error handler                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
@@ -109,19 +106,18 @@ void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteError), DataLength);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteError), WriteResult);
     UT_DEFAULT_IMPL(DS_FileWriteError);
-
-} /* End of DS_FileWriteError() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCreateDest() - create destination file                   */
+/* Create destination file                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCreateDest(uint32 FileIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateDest), FileIndex);
     UT_DEFAULT_IMPL(DS_FileCreateDest);
-} /* End of DS_FileCreateDest() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -132,12 +128,11 @@ void DS_FileCreateName(uint32 FileIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateName), FileIndex);
     UT_DEFAULT_IMPL(DS_FileCreateName);
-
-} /* End of DS_FileCreateName() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCreateSequence() - set text from count or time           */
+/* Set text from count or time                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
@@ -146,12 +141,11 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateSequence), Type);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateSequence), Count);
     UT_DEFAULT_IMPL(DS_FileCreateSequence);
-
-} /* End of DS_FileCreateSequence() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileUpdateHeader() - update destination file header          */
+/* Update destination file header                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -159,33 +153,26 @@ void DS_FileUpdateHeader(int32 FileIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileUpdateHeader), FileIndex);
     UT_DEFAULT_IMPL(DS_FileUpdateHeader);
-
-} /* End of DS_FileUpdateHeader() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileCloseDest() - close destination file                     */
+/* Close destination file                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileCloseDest(int32 FileIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCloseDest), FileIndex);
     UT_DEFAULT_IMPL(DS_FileCloseDest);
-
-} /* End of DS_FileCloseDest() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_FileTestAge() -- file age processor                          */
+/* File age processor                                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void DS_FileTestAge(uint32 ElapsedSeconds)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileTestAge), ElapsedSeconds);
     UT_DEFAULT_IMPL(DS_FileTestAge);
-
-} /* End of DS_FileTestAge() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/stubs/ds_table_stubs.c
+++ b/unit-test/stubs/ds_table_stubs.c
@@ -45,40 +45,40 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableInit() - DS application table initialization            */
+/* DS application table initialization                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 DS_TableInit(void)
 {
     return UT_DEFAULT_IMPL(DS_TableInit);
-} /* End of DS_TableInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableManageDestFile() - manage table data updates            */
+/* Manage table data updates                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableManageDestFile(void)
 {
     UT_DEFAULT_IMPL(DS_TableManageDestFile);
-} /* End of DS_TableManageDestFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableManageFilter() - manage table data updates              */
+/* Manage table data updates                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableManageFilter(void)
 {
     UT_DEFAULT_IMPL(DS_TableManageFilter);
-} /* End of DS_TableManageFilter() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyDestFile() - validate table data                  */
+/* Validate table data                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -86,11 +86,11 @@ int32 DS_TableVerifyDestFile(const void *TableData)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFile), TableData);
     return UT_DEFAULT_IMPL(DS_TableVerifyDestFile);
-} /* End of DS_TableVerifyDestFile() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyDestFileEntry() - verify dest table entry         */
+/* Verify dest table entry                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -100,12 +100,11 @@ bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableI
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFileEntry), TableIndex);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFileEntry), ErrorCount);
     return UT_DEFAULT_IMPL(DS_TableVerifyDestFileEntry);
-
-} /* End of DS_TableVerifyDestFileEntry() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFilter() - validate table data                    */
+/* Validate table data                                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -113,12 +112,11 @@ int32 DS_TableVerifyFilter(const void *TableData)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilter), TableData);
     return UT_DEFAULT_IMPL(DS_TableVerifyFilter);
-
-} /* End of DS_TableVerifyFilter() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFilterEntry() - verify filter table entry         */
+/* Verify filter table entry                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -128,12 +126,11 @@ bool DS_TableVerifyFilterEntry(DS_PacketEntry_t *PacketEntry, int32 TableIndex, 
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilterEntry), TableIndex);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilterEntry), ErrorCount);
     return UT_DEFAULT_IMPL(DS_TableVerifyFilterEntry);
-
-} /* End of DS_TableVerifyFilterEntry() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableEntryUnused() - find unused table entries               */
+/* Find unused table entries                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -142,12 +139,11 @@ bool DS_TableEntryUnused(const void *TableEntry, int32 BufferSize)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableEntryUnused), TableEntry);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableEntryUnused), BufferSize);
     return UT_DEFAULT_IMPL(DS_TableEntryUnused);
-
-} /* End of DS_TableEntryUnused() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyFileIndex() - verify dest file index              */
+/* Verify dest file index                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -155,12 +151,11 @@ bool DS_TableVerifyFileIndex(uint16 FileTableIndex)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFileIndex), FileTableIndex);
     return UT_DEFAULT_IMPL(DS_TableVerifyFileIndex);
-
-} /* End of DS_TableVerifyFileIndex() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyParms() - verify algorithm parameters             */
+/* Verify algorithm parameters                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -170,11 +165,11 @@ bool DS_TableVerifyParms(uint16 Algorithm_N, uint16 Algorithm_X, uint16 Algorith
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyParms), Algorithm_X);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyParms), Algorithm_O);
     return UT_DEFAULT_IMPL(DS_TableVerifyParms);
-} /* End of DS_TableVerifyParms() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyType() - verify filter or filename type           */
+/* Verify filter or filename type                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -182,12 +177,11 @@ bool DS_TableVerifyType(uint16 TimeVsCount)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyType), TimeVsCount);
     return UT_DEFAULT_IMPL(DS_TableVerifyType);
-
-} /* End of DS_TableVerifyType() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyState() - verify file ena/dis state               */
+/* Verify file ena/dis state                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -195,12 +189,11 @@ bool DS_TableVerifyState(uint16 EnableState)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyState), EnableState);
     return UT_DEFAULT_IMPL(DS_TableVerifyState);
-
-} /* End of DS_TableVerifyState() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifySize() - verify file size limit                   */
+/* Verify file size limit                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -208,12 +201,11 @@ bool DS_TableVerifySize(uint32 MaxFileSize)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifySize), MaxFileSize);
     return UT_DEFAULT_IMPL(DS_TableVerifySize);
-
-} /* End of DS_TableVerifySize() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyAge() - verify file age limit                     */
+/* Verify file age limit                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -221,12 +213,11 @@ bool DS_TableVerifyAge(uint32 MaxFileAge)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyAge), MaxFileAge);
     return UT_DEFAULT_IMPL(DS_TableVerifyAge);
-
-} /* End of DS_TableVerifyAge() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableVerifyCount() - verify sequence count                   */
+/* Verify sequence count                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -234,56 +225,55 @@ bool DS_TableVerifyCount(uint32 SequenceCount)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyCount), SequenceCount);
     return UT_DEFAULT_IMPL(DS_TableVerifyCount);
-
-} /* End of DS_TableVerifyCount() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableSubscribe() - process new filter table                  */
+/* Process new filter table                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableSubscribe(void)
 {
     UT_DEFAULT_IMPL(DS_TableSubscribe);
-} /* End of DS_TableSubscribe() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableUnsubscribe() - process old filter table                */
+/* Process old filter table                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableUnsubscribe(void)
 {
     UT_DEFAULT_IMPL(DS_TableUnsubscribe);
-} /* End of DS_TableUnsubscribe() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableCreateCDS() - create DS storage area in CDS             */
+/* Create DS storage area in CDS                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 DS_TableCreateCDS(void)
 {
     return UT_DEFAULT_IMPL(DS_TableCreateCDS);
-} /* End of DS_TableCreateCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableUpdateCDS() - update DS storage area in CDS             */
+/* Update DS storage area in CDS                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableUpdateCDS(void)
 {
     UT_DEFAULT_IMPL(DS_TableUpdateCDS);
-} /* End of DS_TableUpdateCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableHashFunction() - convert messageID to hash table index  */
+/* Convert messageID to hash table index                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -291,22 +281,22 @@ uint32 DS_TableHashFunction(CFE_SB_MsgId_t MessageID)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableHashFunction), MessageID);
     return UT_DEFAULT_IMPL(DS_TableHashFunction);
-} /* End of DS_TableHashFunction() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableCreateHash() - create and populate hash table           */
+/* Create and populate hash table                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 void DS_TableCreateHash(void)
 {
     UT_DEFAULT_IMPL(DS_TableCreateHash);
-} /* End of DS_TableCreateHash() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableFindMsgID() - get filter table index for MID            */
+/* Get filter table index for MID                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -315,12 +305,11 @@ int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableAddMsgID), MessageID);
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableAddMsgID), FilterIndex);
     return UT_DEFAULT_IMPL(DS_TableAddMsgID);
-
-} /* End of DS_TableAddMsgID() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* DS_TableFindMsgID() - get filter table index for MID            */
+/* Get filter table index for MID                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -328,9 +317,4 @@ int32 DS_TableFindMsgID(CFE_SB_MsgId_t MessageID)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableFindMsgID), MessageID);
     return UT_DEFAULT_IMPL(DS_TableFindMsgID);
-
-} /* End of DS_TableFindMsgID() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #57
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 