### PR TITLE
Fix #51, remove mid

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -468,6 +468,13 @@ void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             break;
 
         /*
+        ** Remove message ID from filter table...
+        */
+        case DS_REMOVE_MID_CC:
+            DS_CmdRemoveMID(BufPtr);
+            break;
+
+        /*
         ** Close all destination files (next packet will re-open)...
         */
         case DS_CLOSE_ALL_CC:

--- a/fsw/src/ds_cmds.h
+++ b/fsw/src/ds_cmds.h
@@ -444,4 +444,26 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr);
  */
 void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr);
 
+/**
+ *  \brief Remove Message ID from Packet Filter Table
+ *
+ *  \par Description
+ *       Remove used packet filter table entry
+ *       Reject invalid commands
+ *       - generate error event if invalid command packet length
+ *       - generate error event if MID argument is invalid (cannot be zero)
+ *       - generate error event if packet filter table is not loaded
+ *       - generate error event if MID is not in packet filter table
+ *       Accept valid commands
+ *       - generate success event (event type = debug)
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       (none)
+ *
+ *  \param[in] BufPtr Software Bus message pointer
+ *
+ *  \sa #DS_REMOVE_MID_CC, #DS_RemoveMidCmd_t
+ */
+void DS_CmdRemoveMID(const CFE_SB_Buffer_t *BufPtr);
+
 #endif

--- a/fsw/src/ds_events.h
+++ b/fsw/src/ds_events.h
@@ -850,6 +850,39 @@
  */
 #define DS_APPHK_FILTER_TBL_PRINT_ERR_EID 70
 
+/**
+ *  \brief DS Remove Message ID from Filter Table Command Event ID
+ *
+ *  \par Type: DEBUG
+ *
+ *  \par Cause:
+ *
+ *  This event signals the successful execution of a command to remove
+ *  a message ID from the Packet Filter Table.
+ *
+ *  The Packet Filter Table must be loaded and have a used entry
+ *  for removing the message ID.  The message ID must not be zero
+ *  and must already exist in the table.
+ */
+#define DS_REMOVE_MID_CMD_EID 71
+
+/**
+ *  \brief DS Remove Message ID from Filter Table Command Invalid Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event signals the failed execution of a command to remove a
+ *  message ID from the Packet Filter Table.  The cause of the failure
+ *  may be an invalid command packet length or an invalid message ID.
+ *
+ *  The failure may also result from not having a Packet Filter Table
+ *  loaded at the time the command was invoked.  The loaded table
+ *  must have an entry with the indicated message ID.
+ */
+#define DS_REMOVE_MID_CMD_ERR_EID 72
+
 /**@}*/
 
 #endif

--- a/fsw/src/ds_msg.h
+++ b/fsw/src/ds_msg.h
@@ -269,6 +269,19 @@ typedef struct
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
 } DS_AddMidCmd_t;
 
+/**
+ *  \brief Remove Message ID from Packet Filter Table
+ *
+ *  For command details see #DS_REMOVE_MID_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+
+    CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
+
+} DS_RemoveMidCmd_t;
+
 /**\}*/
 
 /**

--- a/fsw/src/ds_msgdefs.h
+++ b/fsw/src/ds_msgdefs.h
@@ -579,6 +579,37 @@
  */
 #define DS_CLOSE_ALL_CC 17
 
+/**
+ * \brief Remove Message ID from Packet Filter Table
+ *
+ *  \par Description
+ *       This command will change the Message ID selection for a
+ *       used Packet Filter Table entry to unused (0).
+ *
+ *  \par Command Structure
+ *       #DS_RemoveMidCmd_t
+ *
+ *  \par Command Verification
+ *       Evidence of success may be found in the following telemetry:
+ *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - The #DS_REMOVE_MID_CMD_EID debug event message will be sent
+ *
+ *  \par Error Conditions
+ *       This command can fail for the following reasons:
+ *       - Invalid command packet length
+ *       - Message ID is invalid (can be anything but zero)
+ *       - Packet filter table is not currently loaded
+ *       - Message ID does not exist in packet filter table
+ *
+ *       Evidence of failure may be found in the following telemetry:
+ *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - The #DS_REMOVE_MID_CMD_ERR_EID error event message will be sent
+ *
+ *  \par Criticality
+ *       None
+ */
+#define DS_REMOVE_MID_CC 18
+
 /**\}*/
 
 #endif

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -1095,7 +1095,7 @@ int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Get filter table index for MID                                  */
+/* DS_TableFindMsgID() - get filter table index for MID            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 

--- a/unit-test/stubs/ds_cmds_stubs.c
+++ b/unit-test/stubs/ds_cmds_stubs.c
@@ -259,4 +259,21 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdAddMID), BufPtr);
     UT_DEFAULT_IMPL(DS_CmdAddMID);
-}
+} /* End of DS_CmdAddMID() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* DS_CmdRemoveMID() - remove message ID from packet filter table  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void DS_CmdRemoveMID(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdRemoveMID), BufPtr);
+    UT_DEFAULT_IMPL(DS_CmdRemoveMID);
+
+} /* End of DS_CmdRemoveMID() */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/unit-test/stubs/ds_table_stubs.c
+++ b/unit-test/stubs/ds_table_stubs.c
@@ -296,7 +296,7 @@ void DS_TableCreateHash(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Get filter table index for MID                                  */
+/* DS_TableAddMsgID() - get filter table index for MID             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -309,7 +309,7 @@ int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Get filter table index for MID                                  */
+/* DS_TableFindMsgID() - get filter table index for MID            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #51 

**Testing performed**
Steps taken to test the contribution:
* Printed out Filter Table Packet and DS AppData Hash Table Entries after adding a message ID to the Table using `OS_printf`.
* Printed out Filter Table Packet Entries and DS AppData Hash Table Entries after removing that same message ID from the Table using `OS_printf`.
* Observed that the Filter Table entry with the indicated message ID was reset to 0.
* Observed that the DS AppData Hash Table Entry for the removed, indicated message ID was reset.

**Expected behavior changes**
Allows users to remove message IDs from the filter table.

**System(s) tested on**
 - Ubuntu 18.04

**Additional context**
N/A

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
