### PR TITLE
Fix #60, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/ds_events.h
+++ b/fsw/inc/ds_events.h
@@ -39,7 +39,7 @@
  *  This event message is issued if the Data Storage (DS) application successfully
  *  completes its initialization.
  */
-#define DS_INIT_EID 1
+#define DS_INIT_INF_EID 1
 
 /**
  *  \brief DS Initialization Failed Event ID
@@ -242,7 +242,7 @@
  *  these errors so the cause is more likely to result from sending "raw"
  *  ground commands or on-board stored commands.
  */
-#define DS_CMD_CODE_ERR_EID 21
+#define DS_CC_ERR_EID 21
 
 /**
  *  \brief DS Housekeeping Request Invalid Length Event ID
@@ -254,7 +254,7 @@
  *  This event signals the failed execution of a HK request command.
  *  The cause of the failure is an invalid command packet length.
  */
-#define DS_HK_REQUEST_ERR_EID 22
+#define DS_HKREQ_LEN_ERR_EID 22
 
 /**
  *  \brief DS No-op Command Event ID
@@ -267,7 +267,7 @@
  *  command.  The command is used primarily as an indicator that the DS
  *  application can receive commands and generate telemetry.
  */
-#define DS_NOOP_CMD_EID 31
+#define DS_NOOP_INF_EID 31
 
 /**
  *  \brief DS No-op Command Invalid Length Event ID
@@ -284,7 +284,7 @@
 /**
  *  \brief DS Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -292,7 +292,7 @@
  *  counters command.  The command is used primarily to clear counters
  *  that have already been examined.
  */
-#define DS_RESET_CMD_EID 33
+#define DS_RESET_INF_EID 33
 
 /**
  *  \brief DS Reset Counters Command Invalid Length Event ID

--- a/fsw/inc/ds_msgdefs.h
+++ b/fsw/inc/ds_msgdefs.h
@@ -43,7 +43,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_NOOP_CMD_EID informational event message will be sent
+ *       - The #DS_NOOP_INF_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -70,7 +70,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will reset to zero
- *       - The #DS_RESET_CMD_EID debug event message will be sent
+ *       - The #DS_RESET_INF_EID debug event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:

--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -261,7 +261,7 @@ int32 DS_AppInitialize(void)
     */
     if (Result == CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(DS_INIT_EID, CFE_EVS_EventType_INFORMATION,
+        CFE_EVS_SendEvent(DS_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Application initialized, version %d.%d.%d.%d, data at %p", DS_MAJOR_VERSION,
                           DS_MINOR_VERSION, DS_REVISION, DS_MISSION_REV, (void *)&DS_AppData);
     }

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -61,7 +61,7 @@ void DS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
     */
     DS_AppData.CmdAcceptedCounter++;
 
-    CFE_EVS_SendEvent(DS_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "NOOP command, Version %d.%d.%d.%d",
+    CFE_EVS_SendEvent(DS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "NOOP command, Version %d.%d.%d.%d",
                       DS_MAJOR_VERSION, DS_MINOR_VERSION, DS_REVISION, DS_MISSION_REV);
 }
 
@@ -103,7 +103,7 @@ void DS_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     DS_AppData.FilterTblLoadCounter = 0;
     DS_AppData.FilterTblErrCounter  = 0;
 
-    CFE_EVS_SendEvent(DS_RESET_CMD_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(DS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/ds_dispatch.c
+++ b/fsw/src/ds_dispatch.c
@@ -360,7 +360,7 @@ void DS_RemoveMIDVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
 {
-    if (DS_VerifyLength(BufPtr, sizeof(DS_SendHkCmd_t), DS_HK_REQUEST_ERR_EID, "SEND HK"))
+    if (DS_VerifyLength(BufPtr, sizeof(DS_SendHkCmd_t), DS_HKREQ_LEN_ERR_EID, "SEND HK"))
     {
         DS_AppSendHkCmd();
     }
@@ -562,8 +562,8 @@ void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
         ** DS application command with unknown command code...
         */
         default:
-            CFE_EVS_SendEvent(DS_CMD_CODE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid command code: MID = 0x%08X, CC = %d", DS_CMD_MID, CommandCode);
+            CFE_EVS_SendEvent(DS_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command code: MID = 0x%08X, CC = %d",
+                              DS_CMD_MID, CommandCode);
 
             DS_AppData.CmdRejectedCounter++;
             break;

--- a/unit-test/ds_app_tests.c
+++ b/unit-test/ds_app_tests.c
@@ -159,7 +159,7 @@ void DS_AppInitialize_Test_Nominal(void)
      * are modified by subfunctions, which we're not testing here */
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 }
 

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -61,7 +61,7 @@ void DS_NoopCmd_Test_Nominal(void)
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_NOOP_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_NOOP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
@@ -90,7 +90,7 @@ void DS_ResetCountersCmd_Test_Nominal(void)
     UtAssert_ZERO(DS_AppData.FilterTblErrCounter);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_RESET_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_RESET_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */

--- a/unit-test/ds_dispatch_tests.c
+++ b/unit-test/ds_dispatch_tests.c
@@ -138,7 +138,7 @@ void DS_AppProcessMsg_Test_HKInvalidRequest(void)
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_HK_REQUEST_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_HKREQ_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #60
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt