### PR TITLE
Fix #10, Fix nasa/FM#13; Make DS/FM file header sub-types unique

### DIFF
--- a/fsw/inc/ds_platform_cfg.h
+++ b/fsw/inc/ds_platform_cfg.h
@@ -260,7 +260,7 @@
  *       thus the value can be anything from zero to 4,294,967,295.
  *       (limit is not verified)
  */
-#define DS_FILE_HDR_SUBTYPE 12345
+#define DS_FILE_HDR_SUBTYPE 0x2710
 
 /**
  *  \brief Data Storage File -- cFE file header description


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #10 and Fixes https://github.com/nasa/FM/issues/13
Updates `DS_FILE_HDR_SUBTYPE` value to make it unique (not the same as `FM_DIR_LIST_FILE_SUBTYPE`).

**Testing performed**
Just GitHub CI actions (incl. build + run).

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt