### PR TITLE
Fix #63, Change format string to avoid GCC workflow failure

### DIFF
--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -879,7 +879,7 @@ void DS_FileCloseDest(int32 FileIndex)
             ** Error - send event but leave destination enabled...
             */
             CFE_EVS_SendEvent(DS_MOVE_FILE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "FILE MOVE error: dir name = '%s', filename = '%s'", PathName, FileName);
+                              "FILE MOVE error: dir name = '%s', filename = 'NULL'", PathName);
         }
 
         /* Update the path name for reporting */


### PR DESCRIPTION
*Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #63 
Format string in `CFE_EVS_SendEvent` instance changed to avoid potential `NULL` argument being passed in to "`%s`" format specifier, which causes a GCC error and workflow failure.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Workflow (Build + Run) will complete without GCC error causing failure.

**Contributor Info**
Avi @thnkslprpt