### PR TITLE
Fix #12, Use CFE_MSG_PTR macro

### DIFF
--- a/fsw/inc/ds_msg.h
+++ b/fsw/inc/ds_msg.h
@@ -39,7 +39,7 @@
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 } DS_NoopCmd_t;
 
 /**
@@ -49,7 +49,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 } DS_ResetCmd_t;
 
 /**
@@ -59,7 +59,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 EnableState; /**< \brief Application enable/disable state */
     uint16 Padding;     /**< \brief Structure Padding on 32-bit boundaries */
@@ -72,7 +72,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
@@ -87,7 +87,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
@@ -102,7 +102,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
@@ -119,7 +119,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 FileNameType;   /**< \brief Filename type - count vs time */
@@ -132,7 +132,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 EnableState;    /**< \brief File enable/disable state */
@@ -145,7 +145,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
     uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
@@ -159,7 +159,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
     uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
@@ -173,7 +173,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex;                  /**< \brief Index into Destination File Table */
     uint16 Padding;                         /**< \brief Structure Padding on 32-bit boundaries */
@@ -187,7 +187,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
@@ -201,7 +201,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
@@ -216,7 +216,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
@@ -231,7 +231,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
@@ -244,7 +244,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 } DS_CloseAllCmd_t;
 
 /**
@@ -254,7 +254,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 } DS_GetFileInfoCmd_t;
 
 /**
@@ -264,7 +264,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
 } DS_AddMidCmd_t;
@@ -276,7 +276,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief cFE Software Bus command message header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
 
@@ -294,7 +294,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief cFE Software Bus telemetry message header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
 
     uint8  CmdAcceptedCounter;                 /**< \brief Count of valid commands received */
     uint8  CmdRejectedCounter;                 /**< \brief Count of invalid commands received */
@@ -340,7 +340,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief cFE Software Bus telemetry message header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
 
     DS_FileInfo_t FileInfo[DS_DEST_FILE_CNT]; /**< \brief Current state of destination files */
 } DS_FileInfoPkt_t;
@@ -350,7 +350,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief cFE Software Bus telemetry message header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
 
     DS_FileInfo_t FileInfo; /**< \brief Current state of destination file */
 } DS_FileCompletePkt_t;

--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -512,7 +512,7 @@ void DS_AppProcessHK(void)
     /*
     ** Initialize housekeeping packet...
     */
-    CFE_MSG_Init(&HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(DS_HK_TLM_MID), sizeof(DS_HkPacket_t));
+    CFE_MSG_Init(CFE_MSG_PTR(HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(DS_HK_TLM_MID), sizeof(DS_HkPacket_t));
 
     /*
     ** Process data storage file age limits...
@@ -603,8 +603,8 @@ void DS_AppProcessHK(void)
     /*
     ** Timestamp and send housekeeping telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(HkPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(HkPacket.TelemetryHeader), true);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -1269,7 +1269,8 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
         /*
         ** Initialize file info telemetry packet...
         */
-        CFE_MSG_Init(&DS_FileInfoPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(DS_DIAG_TLM_MID), sizeof(DS_FileInfoPkt_t));
+        CFE_MSG_Init(CFE_MSG_PTR(DS_FileInfoPkt.TelemetryHeader), CFE_SB_ValueToMsgId(DS_DIAG_TLM_MID),
+                     sizeof(DS_FileInfoPkt_t));
 
         /*
         ** Process array of destination file info data...
@@ -1326,8 +1327,8 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
         /*
         ** Timestamp and send file info telemetry packet...
         */
-        CFE_SB_TimeStampMsg(&DS_FileInfoPkt.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&DS_FileInfoPkt.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(DS_FileInfoPkt.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(DS_FileInfoPkt.TelemetryHeader), true);
     }
 }
 

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -958,6 +958,7 @@ void DS_FileTestAge(uint32 ElapsedSeconds)
 void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
 {
     DS_FileCompletePktBuf_t *PktBuf;
+    DS_FileInfo_t *          FileInfo;
 
     /*
     ** Get a Message block of memory and initialize it
@@ -969,38 +970,40 @@ void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
     */
     if (PktBuf != NULL)
     {
-        CFE_MSG_Init(&PktBuf->Pkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(DS_COMP_TLM_MID), sizeof(*PktBuf));
+        CFE_MSG_Init(CFE_MSG_PTR(PktBuf->Pkt.TelemetryHeader), CFE_SB_ValueToMsgId(DS_COMP_TLM_MID), sizeof(*PktBuf));
+
+        FileInfo = &PktBuf->Pkt.FileInfo;
 
         /*
         ** Set file age and size...
         */
-        PktBuf->Pkt.FileInfo.FileAge  = FileStatus->FileAge;
-        PktBuf->Pkt.FileInfo.FileSize = FileStatus->FileSize;
+        FileInfo->FileAge  = FileStatus->FileAge;
+        FileInfo->FileSize = FileStatus->FileSize;
         /*
         ** Set file growth rate (computed when process last HK request)...
         */
-        PktBuf->Pkt.FileInfo.FileRate = FileStatus->FileRate;
+        FileInfo->FileRate = FileStatus->FileRate;
         /*
         ** Set current filename sequence count...
         */
-        PktBuf->Pkt.FileInfo.SequenceCount = FileStatus->FileCount;
+        FileInfo->SequenceCount = FileStatus->FileCount;
         /*
         ** Set file enable/disable state...
         */
-        PktBuf->Pkt.FileInfo.EnableState = FileStatus->FileState;
+        FileInfo->EnableState = FileStatus->FileState;
         /*
         ** Set file closed state...
         */
-        PktBuf->Pkt.FileInfo.OpenState = DS_CLOSED;
+        FileInfo->OpenState = DS_CLOSED;
         /*
         ** Set current open filename...
         */
-        strncpy(PktBuf->Pkt.FileInfo.FileName, FileStatus->FileName, sizeof(PktBuf->Pkt.FileInfo.FileName));
+        strncpy(FileInfo->FileName, FileStatus->FileName, sizeof(FileInfo->FileName));
 
         /*
         ** Timestamp and send file info telemetry...
         */
-        CFE_SB_TimeStampMsg(&PktBuf->Pkt.TlmHeader.Msg);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(PktBuf->Pkt.TelemetryHeader));
         CFE_SB_TransmitBuffer(&PktBuf->SBBuf, true);
     }
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This updates DS to use the CFE_MSG_PTR macro.  This macro is provided by the CFE "msg" module to convert a local header buffer to the base struct type.  

Use of this macro requires that the naming convention was followed, so this also means renaming `TlmHeader` -> `TelemetryHeader` and `CmdHeader` -> `CommandHeader`.

Fixes #12

**Testing performed**
Build and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
This matches the current naming, usage patterns, and recommended practices used in CFE, thereby bringing DS more up to date.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
