### PR TITLE
Fix #85, Change EVS_Register failure from SendEvent to WriteToSysLog

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -201,8 +201,7 @@ int32 DS_AppInitialize(void)
 
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(DS_INIT_ERR_EID, CFE_EVS_EventType_ERROR, "Unable to register for EVS services, err = 0x%08X",
-                          (unsigned int)Result);
+        CFE_ES_WriteToSysLog("DS App: Error registering for Event Services, RC = 0x%08X\n", (unsigned int)Result);
     }
 
     /*

--- a/unit-test/ds_app_tests.c
+++ b/unit-test/ds_app_tests.c
@@ -98,11 +98,11 @@ void DS_AppMain_Test_AppInitializeError(void)
     DS_AppMain();
 
     /* Verify results */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, DS_EXIT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_CRITICAL);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_EXIT_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_CRITICAL);
     UtAssert_STUB_COUNT(CFE_ES_ExitApp, 1);
-    UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
+    UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 2);
 }
 
 void DS_AppMain_Test_SBError(void)
@@ -179,11 +179,7 @@ void DS_AppInitialize_Test_EVSRegisterError(void)
     UtAssert_BOOL_FALSE(OS_ObjectIdDefined(DS_AppData.FileStatus[DS_DEST_FILE_CNT / 2].FileHandle));
     UtAssert_BOOL_FALSE(OS_ObjectIdDefined(DS_AppData.FileStatus[DS_DEST_FILE_CNT - 1].FileHandle));
 
-    /* Note: not verifying that rest of DS_AppData is set to 0, because some elements of DS_AppData
-     * are modified by subfunctions, which we're not testing here */
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_INIT_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_STUB_COUNT(CFE_ES_WriteToSysLog, 1);
 }
 
 void DS_AppInitialize_Test_SBCreatePipeError(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #85
`CFE_EVS_SendEvent` replaced by `CFE_ES_WriteToSysLog` on failure of `CFE_EVS_Register`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Coverage maintained at 100%:
```
  lines......: 100.0% (1311 of 1311 lines)
  functions..: 100.0% (66 of 66 functions)
  branches...: 100.0% (485 of 485 branches)
```

**Expected behavior changes**
Failure can be successfully recorded somewhere even without the EVS now.

**Contributor Info**
Avi Weiss @thnkslprpt