### PR TITLE
Fix #90, Rename SB Command Pipe to CmdPipe

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -98,7 +98,7 @@ void DS_AppMain(void)
         /*
         ** Wait for next Software Bus message...
         */
-        Result = CFE_SB_ReceiveBuffer(&BufPtr, DS_AppData.InputPipe, DS_SB_TIMEOUT);
+        Result = CFE_SB_ReceiveBuffer(&BufPtr, DS_AppData.CmdPipe, DS_SB_TIMEOUT);
 
         /*
         ** Performance Log (start time counter)...
@@ -210,7 +210,7 @@ int32 DS_AppInitialize(void)
     */
     if (Result == CFE_SUCCESS)
     {
-        Result = CFE_SB_CreatePipe(&DS_AppData.InputPipe, DS_APP_PIPE_DEPTH, DS_APP_PIPE_NAME);
+        Result = CFE_SB_CreatePipe(&DS_AppData.CmdPipe, DS_APP_PIPE_DEPTH, DS_APP_PIPE_NAME);
         if (Result != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(DS_INIT_ERR_EID, CFE_EVS_EventType_ERROR, "Unable to create input pipe, err = 0x%08X",
@@ -223,7 +223,7 @@ int32 DS_AppInitialize(void)
     */
     if (Result == CFE_SUCCESS)
     {
-        Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(DS_SEND_HK_MID), DS_AppData.InputPipe);
+        Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(DS_SEND_HK_MID), DS_AppData.CmdPipe);
 
         if (Result != CFE_SUCCESS)
         {
@@ -237,7 +237,7 @@ int32 DS_AppInitialize(void)
     */
     if (Result == CFE_SUCCESS)
     {
-        Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_AppData.InputPipe);
+        Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_AppData.CmdPipe);
 
         if (Result != CFE_SUCCESS)
         {

--- a/fsw/src/ds_app.h
+++ b/fsw/src/ds_app.h
@@ -71,7 +71,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_SB_PipeId_t InputPipe; /**< \brief Pipe Id for DS command pipe */
+    CFE_SB_PipeId_t CmdPipe; /**< \brief Pipe Id for DS command pipe */
 
     CFE_ES_CDSHandle_t DataStoreHandle; /**< \brief Critical Data Store (CDS) handle */
 

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -1431,7 +1431,7 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
             pFilterParms->Algorithm_O = 0;
         }
 
-        CFE_SB_SubscribeEx(DS_AddMidCmd->MessageID, DS_AppData.InputPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
+        CFE_SB_SubscribeEx(DS_AddMidCmd->MessageID, DS_AppData.CmdPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
         /*
         ** Notify cFE that we have modified the table data...
         */
@@ -1536,7 +1536,7 @@ void DS_CmdRemoveMID(const CFE_SB_Buffer_t *BufPtr)
             pFilterParms->Algorithm_O = 0;
         }
 
-        CFE_SB_Unsubscribe(DS_RemoveMidCmd->MessageID, DS_AppData.InputPipe);
+        CFE_SB_Unsubscribe(DS_RemoveMidCmd->MessageID, DS_AppData.CmdPipe);
 
         /*
         ** Notify cFE that we have modified the table data...

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -826,7 +826,7 @@ void DS_TableSubscribe(void)
         if (CFE_SB_IsValidMsgId(MessageID) && (CFE_SB_MsgIdToValue(MessageID) != DS_CMD_MID) &&
             (CFE_SB_MsgIdToValue(MessageID) != DS_SEND_HK_MID))
         {
-            CFE_SB_SubscribeEx(MessageID, DS_AppData.InputPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
+            CFE_SB_SubscribeEx(MessageID, DS_AppData.CmdPipe, CFE_SB_DEFAULT_QOS, DS_PER_PACKET_PIPE_LIMIT);
         }
     }
 }
@@ -858,7 +858,7 @@ void DS_TableUnsubscribe(void)
         if (CFE_SB_IsValidMsgId(MessageID) && (CFE_SB_MsgIdToValue(MessageID) != DS_CMD_MID) &&
             (CFE_SB_MsgIdToValue(MessageID) != DS_SEND_HK_MID))
         {
-            CFE_SB_Unsubscribe(MessageID, DS_AppData.InputPipe);
+            CFE_SB_Unsubscribe(MessageID, DS_AppData.CmdPipe);
         }
     }
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #90 
`InputPipe` global data struct member renamed to `CmdPipe`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.
DS's SB command pipe struct member is now named consistently with the rest of cFS and the other apps which improves future maintainability.

**Contributor Info**
Avi Weiss @thnkslprpt