### PR TITLE
Fix #100, use generated stubs

### DIFF
--- a/fsw/src/ds_file.h
+++ b/fsw/src/ds_file.h
@@ -27,6 +27,7 @@
 #include "cfe.h"
 
 #include "ds_platform_cfg.h"
+#include "ds_app.h"
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -10,9 +10,10 @@
 add_cfe_coverage_stubs("ds_internal"
   utilities/ds_test_utils.c
   stubs/ds_app_stubs.c
-  stubs/ds_file_stubs.c
-  stubs/ds_table_stubs.c
   stubs/ds_cmds_stubs.c
+  stubs/ds_file_stubs.c
+  stubs/ds_global_stubs.c
+  stubs/ds_table_stubs.c
   stubs/stub_libc_stdio.c
 )
 
@@ -27,18 +28,18 @@ target_include_directories(coverage-ds_internal-stubs PUBLIC ../fsw/src)
 # Stub includes needed for all targets
 include_directories(stubs)
 
-# Generate a dedicated "testrunner" executable for each test file 
+# Generate a dedicated "testrunner" executable for each test file
 # Accomplish this by cycling through all the app's source files, there must be
 # a *_tests file for each
 foreach(SRCFILE ${APP_SRC_FILES})
-    
-    # Get the base sourcefile name as a module name without path or the  
+
+    # Get the base sourcefile name as a module name without path or the
     # extension, this will be used as the base name of the unit test file.
     get_filename_component(UNIT_NAME "${SRCFILE}" NAME_WE)
 
     # Use the module name to make the test name by adding _tests to the end
     set(TESTS_NAME "${UNIT_NAME}_tests")
-    
+
     # Make the test sourcefile name with unit test path and extension
     set(TESTS_SOURCE_FILE "${PROJECT_SOURCE_DIR}/unit-test/${TESTS_NAME}.c")
 
@@ -52,5 +53,5 @@ foreach(SRCFILE ${APP_SRC_FILES})
     target_include_directories(coverage-ds-${UNIT_NAME}-object BEFORE PRIVATE
         stubs/override_inc
     )
-    
+
 endforeach()

--- a/unit-test/stubs/ds_app_stubs.c
+++ b/unit-test/stubs/ds_app_stubs.c
@@ -19,109 +19,82 @@
 
 /**
  * @file
- *  Unit testing stubs for the ds_app.c file.
+ *
+ * Auto-Generated stub implementations for functions defined in ds_app header
  */
 
-#include "cfe.h"
-
-#include "ds_perfids.h"
-#include "ds_msgids.h"
-
-#include "ds_platform_cfg.h"
-#include "ds_verify.h"
-
-#include "ds_appdefs.h"
-
-#include "ds_msg.h"
 #include "ds_app.h"
-#include "ds_cmds.h"
-#include "ds_file.h"
-#include "ds_table.h"
-#include "ds_events.h"
-#include "ds_msgdefs.h"
-#include "ds_version.h"
+#include "utgenstub.h"
 
-#include <stdio.h>
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Application global data structure                               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-DS_AppData_t DS_AppData;
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Application entry point and main process loop                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_AppMain(void)
-{
-    UT_DEFAULT_IMPL(DS_AppMain);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Application initialization                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppInitialize()
+ * ----------------------------------------------------
+ */
 int32 DS_AppInitialize(void)
 {
-    return UT_DEFAULT_IMPL(DS_AppInitialize);
+    UT_GenStub_SetupReturnBuffer(DS_AppInitialize, int32);
+
+    UT_GenStub_Execute(DS_AppInitialize, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_AppInitialize, int32);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Process Software Bus messages                                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_AppProcessMsg(const CFE_SB_Buffer_t *BufPtr)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppMain()
+ * ----------------------------------------------------
+ */
+void DS_AppMain(void)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppProcessMsg), BufPtr);
-    UT_DEFAULT_IMPL(DS_AppProcessMsg);
+
+    UT_GenStub_Execute(DS_AppMain, Basic, NULL);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Process application commands                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppProcessCmd()
+ * ----------------------------------------------------
+ */
 void DS_AppProcessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppProcessCmd), BufPtr);
-    UT_DEFAULT_IMPL(DS_AppProcessCmd);
+    UT_GenStub_AddParam(DS_AppProcessCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_AppProcessCmd, Basic, NULL);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Process hk request command                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppProcessHK()
+ * ----------------------------------------------------
+ */
 void DS_AppProcessHK(void)
 {
-    UT_DEFAULT_IMPL(DS_AppProcessHK);
+
+    UT_GenStub_Execute(DS_AppProcessHK, Basic, NULL);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Packet storage pre-processor                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppProcessMsg()
+ * ----------------------------------------------------
+ */
+void DS_AppProcessMsg(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_AppProcessMsg, const CFE_SB_Buffer_t *, BufPtr);
 
+    UT_GenStub_Execute(DS_AppProcessMsg, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_AppStorePacket()
+ * ----------------------------------------------------
+ */
 void DS_AppStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppStorePacket), MessageID);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_AppStorePacket), BufPtr);
-    UT_DEFAULT_IMPL(DS_AppStorePacket);
+    UT_GenStub_AddParam(DS_AppStorePacket, CFE_SB_MsgId_t, MessageID);
+    UT_GenStub_AddParam(DS_AppStorePacket, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_AppStorePacket, Basic, NULL);
 }

--- a/unit-test/stubs/ds_cmds_stubs.c
+++ b/unit-test/stubs/ds_cmds_stubs.c
@@ -19,261 +19,237 @@
 
 /**
  * @file
- *  Unit testing stubs for the ds_cmds.c file.
+ *
+ * Auto-Generated stub implementations for functions defined in ds_cmds header
  */
 
-#include "cfe.h"
-
-#include "ds_platform_cfg.h"
-#include "ds_verify.h"
-
-#include "ds_appdefs.h"
-#include "ds_msgids.h"
-
-#include "ds_msg.h"
-#include "ds_app.h"
 #include "ds_cmds.h"
-#include "ds_file.h"
-#include "ds_table.h"
-#include "ds_events.h"
-#include "ds_version.h"
+#include "utgenstub.h"
 
-#include <stdio.h>
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* NOOP command                                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdNoop(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdNoop), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdNoop);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Reset hk telemetry counters command                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdReset), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdReset);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set application ena/dis state                                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetAppState), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetAppState);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set packet filter file index                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterFile), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetFilterFile);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set pkt filter filename type                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterType), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetFilterType);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set packet filter parameters                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetFilterParms), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetFilterParms);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set destination filename type                                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestType), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestType);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set dest file ena/dis state                                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestState), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestState);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set path portion of filename                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestPath), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestPath);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set base portion of filename                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestBase), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestBase);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set extension portion of filename                               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestExt), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestExt);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set maximum file size limit                                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestSize), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestSize);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set maximum file age limit                                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestAge), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestAge);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set seq cnt portion of filename                                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdSetDestCount), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdSetDestCount);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Close destination file                                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdCloseFile), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdCloseFile);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Close all open destination files                                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdCloseAll), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdCloseAll);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Get file info packet                                            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdGetFileInfo), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdGetFileInfo);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Add message ID to packet filter table                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdAddMID()
+ * ----------------------------------------------------
+ */
 void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdAddMID), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdAddMID);
-} /* End of DS_CmdAddMID() */
+    UT_GenStub_AddParam(DS_CmdAddMID, const CFE_SB_Buffer_t *, BufPtr);
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* DS_CmdRemoveMID() - remove message ID from packet filter table  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+    UT_GenStub_Execute(DS_CmdAddMID, Basic, NULL);
+}
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdCloseAll()
+ * ----------------------------------------------------
+ */
+void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdCloseAll, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdCloseAll, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdCloseFile()
+ * ----------------------------------------------------
+ */
+void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdCloseFile, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdCloseFile, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdGetFileInfo()
+ * ----------------------------------------------------
+ */
+void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdGetFileInfo, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdGetFileInfo, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdNoop()
+ * ----------------------------------------------------
+ */
+void DS_CmdNoop(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdNoop, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdNoop, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdRemoveMID()
+ * ----------------------------------------------------
+ */
 void DS_CmdRemoveMID(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_CmdRemoveMID), BufPtr);
-    UT_DEFAULT_IMPL(DS_CmdRemoveMID);
+    UT_GenStub_AddParam(DS_CmdRemoveMID, const CFE_SB_Buffer_t *, BufPtr);
 
-} /* End of DS_CmdRemoveMID() */
+    UT_GenStub_Execute(DS_CmdRemoveMID, Basic, NULL);
+}
 
-/************************/
-/*  End of File Comment */
-/************************/
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdReset()
+ * ----------------------------------------------------
+ */
+void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdReset, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdReset, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetAppState()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetAppState, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetAppState, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestAge()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestAge, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestAge, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestBase()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestBase, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestBase, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestCount()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestCount, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestCount, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestExt()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestExt, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestExt, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestPath()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestPath, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestPath, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestSize()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestSize, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestSize, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestState()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestState, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestState, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetDestType()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetDestType, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetDestType, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetFilterFile()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetFilterFile, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetFilterFile, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetFilterParms()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetFilterParms, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetFilterParms, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_CmdSetFilterType()
+ * ----------------------------------------------------
+ */
+void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_CmdSetFilterType, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_CmdSetFilterType, Basic, NULL);
+}

--- a/unit-test/stubs/ds_file_stubs.c
+++ b/unit-test/stubs/ds_file_stubs.c
@@ -19,160 +19,182 @@
 
 /**
  * @file
- *  Unit testing stubs for the ds_file.c file.
+ *
+ * Auto-Generated stub implementations for functions defined in ds_file header
  */
 
-#include "cfe.h"
-#include "cfe_fs.h"
-
-#include "ds_platform_cfg.h"
-#include "ds_verify.h"
-
-#include "ds_appdefs.h"
-
-#include "ds_msg.h"
-#include "ds_app.h"
 #include "ds_file.h"
-#include "ds_table.h"
-#include "ds_events.h"
+#include "utgenstub.h"
 
-#include <stdio.h>
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Store packet in file(s)                                         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_FileStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileStorePacket), MessageID);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileStorePacket), BufPtr);
-    UT_DEFAULT_IMPL(DS_FileStorePacket);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Prepare to write packet data to file                            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_FileSetupWrite(int32 FileIndex, const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileSetupWrite), FileIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileSetupWrite), BufPtr);
-    UT_DEFAULT_IMPL(DS_FileSetupWrite);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Write data to destination file                                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_FileWriteData(int32 FileIndex, const void *FileData, uint32 DataLength)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteData), FileIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteData), FileData);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteData), DataLength);
-    UT_DEFAULT_IMPL(DS_FileWriteData);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Write header to destination file                                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_FileWriteHeader(int32 FileIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteHeader), FileIndex);
-    UT_DEFAULT_IMPL(DS_FileWriteHeader);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* File write error handler                                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteError), FileIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteError), DataLength);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileWriteError), WriteResult);
-    UT_DEFAULT_IMPL(DS_FileWriteError);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Create destination file                                         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void DS_FileCreateDest(uint32 FileIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateDest), FileIndex);
-    UT_DEFAULT_IMPL(DS_FileCreateDest);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Create destination filename                                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void DS_FileCreateName(uint32 FileIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateName), FileIndex);
-    UT_DEFAULT_IMPL(DS_FileCreateName);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Set text from count or time                                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateSequence), Buffer);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateSequence), Type);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCreateSequence), Count);
-    UT_DEFAULT_IMPL(DS_FileCreateSequence);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Update destination file header                                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_FileUpdateHeader(int32 FileIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileUpdateHeader), FileIndex);
-    UT_DEFAULT_IMPL(DS_FileUpdateHeader);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Close destination file                                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileCloseDest()
+ * ----------------------------------------------------
+ */
 void DS_FileCloseDest(int32 FileIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileCloseDest), FileIndex);
-    UT_DEFAULT_IMPL(DS_FileCloseDest);
+    UT_GenStub_AddParam(DS_FileCloseDest, int32, FileIndex);
+
+    UT_GenStub_Execute(DS_FileCloseDest, Basic, NULL);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* File age processor                                              */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileCreateDest()
+ * ----------------------------------------------------
+ */
+void DS_FileCreateDest(uint32 FileIndex)
+{
+    UT_GenStub_AddParam(DS_FileCreateDest, uint32, FileIndex);
+
+    UT_GenStub_Execute(DS_FileCreateDest, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileCreateName()
+ * ----------------------------------------------------
+ */
+void DS_FileCreateName(uint32 FileIndex)
+{
+    UT_GenStub_AddParam(DS_FileCreateName, uint32, FileIndex);
+
+    UT_GenStub_Execute(DS_FileCreateName, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileCreateSequence()
+ * ----------------------------------------------------
+ */
+void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
+{
+    UT_GenStub_AddParam(DS_FileCreateSequence, char *, Buffer);
+    UT_GenStub_AddParam(DS_FileCreateSequence, uint32, Type);
+    UT_GenStub_AddParam(DS_FileCreateSequence, uint32, Count);
+
+    UT_GenStub_Execute(DS_FileCreateSequence, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileSetupWrite()
+ * ----------------------------------------------------
+ */
+void DS_FileSetupWrite(int32 FileIndex, const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_FileSetupWrite, int32, FileIndex);
+    UT_GenStub_AddParam(DS_FileSetupWrite, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_FileSetupWrite, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileStorePacket()
+ * ----------------------------------------------------
+ */
+void DS_FileStorePacket(CFE_SB_MsgId_t MessageID, const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(DS_FileStorePacket, CFE_SB_MsgId_t, MessageID);
+    UT_GenStub_AddParam(DS_FileStorePacket, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(DS_FileStorePacket, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileTestAge()
+ * ----------------------------------------------------
+ */
 void DS_FileTestAge(uint32 ElapsedSeconds)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_FileTestAge), ElapsedSeconds);
-    UT_DEFAULT_IMPL(DS_FileTestAge);
+    UT_GenStub_AddParam(DS_FileTestAge, uint32, ElapsedSeconds);
+
+    UT_GenStub_Execute(DS_FileTestAge, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileTransmit()
+ * ----------------------------------------------------
+ */
+void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
+{
+    UT_GenStub_AddParam(DS_FileTransmit, DS_AppFileStatus_t *, FileStatus);
+
+    UT_GenStub_Execute(DS_FileTransmit, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileUpdateHeader()
+ * ----------------------------------------------------
+ */
+void DS_FileUpdateHeader(int32 FileIndex)
+{
+    UT_GenStub_AddParam(DS_FileUpdateHeader, int32, FileIndex);
+
+    UT_GenStub_Execute(DS_FileUpdateHeader, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileWriteData()
+ * ----------------------------------------------------
+ */
+void DS_FileWriteData(int32 FileIndex, const void *FileData, uint32 DataLength)
+{
+    UT_GenStub_AddParam(DS_FileWriteData, int32, FileIndex);
+    UT_GenStub_AddParam(DS_FileWriteData, const void *, FileData);
+    UT_GenStub_AddParam(DS_FileWriteData, uint32, DataLength);
+
+    UT_GenStub_Execute(DS_FileWriteData, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileWriteError()
+ * ----------------------------------------------------
+ */
+void DS_FileWriteError(uint32 FileIndex, uint32 DataLength, int32 WriteResult)
+{
+    UT_GenStub_AddParam(DS_FileWriteError, uint32, FileIndex);
+    UT_GenStub_AddParam(DS_FileWriteError, uint32, DataLength);
+    UT_GenStub_AddParam(DS_FileWriteError, int32, WriteResult);
+
+    UT_GenStub_Execute(DS_FileWriteError, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_FileWriteHeader()
+ * ----------------------------------------------------
+ */
+void DS_FileWriteHeader(int32 FileIndex)
+{
+    UT_GenStub_AddParam(DS_FileWriteHeader, int32, FileIndex);
+
+    UT_GenStub_Execute(DS_FileWriteHeader, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_IsPacketFiltered()
+ * ----------------------------------------------------
+ */
+bool DS_IsPacketFiltered(CFE_MSG_Message_t *MessagePtr, uint16 FilterType, uint16 Algorithm_N, uint16 Algorithm_X,
+                         uint16 Algorithm_O)
+{
+    UT_GenStub_SetupReturnBuffer(DS_IsPacketFiltered, bool);
+
+    UT_GenStub_AddParam(DS_IsPacketFiltered, CFE_MSG_Message_t *, MessagePtr);
+    UT_GenStub_AddParam(DS_IsPacketFiltered, uint16, FilterType);
+    UT_GenStub_AddParam(DS_IsPacketFiltered, uint16, Algorithm_N);
+    UT_GenStub_AddParam(DS_IsPacketFiltered, uint16, Algorithm_X);
+    UT_GenStub_AddParam(DS_IsPacketFiltered, uint16, Algorithm_O);
+
+    UT_GenStub_Execute(DS_IsPacketFiltered, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_IsPacketFiltered, bool);
 }

--- a/unit-test/stubs/ds_global_stubs.c
+++ b/unit-test/stubs/ds_global_stubs.c
@@ -1,0 +1,38 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,917-1, and identified as “CFS Data Storage
+ * (DS) application version 2.6.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  Unit testing stubs for the ds_app.c file.
+ */
+
+#include "ds_app.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Application global data structure                               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+DS_AppData_t DS_AppData;

--- a/unit-test/stubs/ds_table_stubs.c
+++ b/unit-test/stubs/ds_table_stubs.c
@@ -19,302 +19,351 @@
 
 /**
  * @file
- *  CFS Data Storage (DS) table management functions
+ *
+ * Auto-Generated stub implementations for functions defined in ds_table header
  */
 
-#include "cfe.h"
-
-#include "ds_msgids.h"
-
-#include "ds_platform_cfg.h"
-#include "ds_verify.h"
-
-#include "ds_appdefs.h"
-
-#include "ds_app.h"
 #include "ds_table.h"
-#include "ds_msg.h"
-#include "ds_events.h"
+#include "utgenstub.h"
 
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-#define DS_CDS_NAME "DS_CDS"
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* DS application table initialization                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-int32 DS_TableInit(void)
-{
-    return UT_DEFAULT_IMPL(DS_TableInit);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Manage table data updates                                       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableManageDestFile(void)
-{
-    UT_DEFAULT_IMPL(DS_TableManageDestFile);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Manage table data updates                                       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableManageFilter(void)
-{
-    UT_DEFAULT_IMPL(DS_TableManageFilter);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Validate table data                                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-int32 DS_TableVerifyDestFile(const void *TableData)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFile), TableData);
-    return UT_DEFAULT_IMPL(DS_TableVerifyDestFile);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify dest table entry                                         */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableIndex, int32 ErrorCount)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFileEntry), DestFileEntry);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFileEntry), TableIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyDestFileEntry), ErrorCount);
-    return UT_DEFAULT_IMPL(DS_TableVerifyDestFileEntry);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Validate table data                                             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-int32 DS_TableVerifyFilter(const void *TableData)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilter), TableData);
-    return UT_DEFAULT_IMPL(DS_TableVerifyFilter);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify filter table entry                                       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyFilterEntry(DS_PacketEntry_t *PacketEntry, int32 TableIndex, int32 ErrorCount)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilterEntry), PacketEntry);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilterEntry), TableIndex);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFilterEntry), ErrorCount);
-    return UT_DEFAULT_IMPL(DS_TableVerifyFilterEntry);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Find unused table entries                                       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableEntryUnused(const void *TableEntry, int32 BufferSize)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableEntryUnused), TableEntry);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableEntryUnused), BufferSize);
-    return UT_DEFAULT_IMPL(DS_TableEntryUnused);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify dest file index                                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyFileIndex(uint16 FileTableIndex)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyFileIndex), FileTableIndex);
-    return UT_DEFAULT_IMPL(DS_TableVerifyFileIndex);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify algorithm parameters                                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyParms(uint16 Algorithm_N, uint16 Algorithm_X, uint16 Algorithm_O)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyParms), Algorithm_N);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyParms), Algorithm_X);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyParms), Algorithm_O);
-    return UT_DEFAULT_IMPL(DS_TableVerifyParms);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify filter or filename type                                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyType(uint16 TimeVsCount)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyType), TimeVsCount);
-    return UT_DEFAULT_IMPL(DS_TableVerifyType);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify file ena/dis state                                       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyState(uint16 EnableState)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyState), EnableState);
-    return UT_DEFAULT_IMPL(DS_TableVerifyState);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify file size limit                                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifySize(uint32 MaxFileSize)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifySize), MaxFileSize);
-    return UT_DEFAULT_IMPL(DS_TableVerifySize);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify file age limit                                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyAge(uint32 MaxFileAge)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyAge), MaxFileAge);
-    return UT_DEFAULT_IMPL(DS_TableVerifyAge);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify sequence count                                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-bool DS_TableVerifyCount(uint32 SequenceCount)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableVerifyCount), SequenceCount);
-    return UT_DEFAULT_IMPL(DS_TableVerifyCount);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Process new filter table                                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableSubscribe(void)
-{
-    UT_DEFAULT_IMPL(DS_TableSubscribe);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Process old filter table                                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableUnsubscribe(void)
-{
-    UT_DEFAULT_IMPL(DS_TableUnsubscribe);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Create DS storage area in CDS                                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-int32 DS_TableCreateCDS(void)
-{
-    return UT_DEFAULT_IMPL(DS_TableCreateCDS);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Update DS storage area in CDS                                   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableUpdateCDS(void)
-{
-    UT_DEFAULT_IMPL(DS_TableUpdateCDS);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Convert messageID to hash table index                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-uint32 DS_TableHashFunction(CFE_SB_MsgId_t MessageID)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableHashFunction), MessageID);
-    return UT_DEFAULT_IMPL(DS_TableHashFunction);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Create and populate hash table                                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-void DS_TableCreateHash(void)
-{
-    UT_DEFAULT_IMPL(DS_TableCreateHash);
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* DS_TableAddMsgID() - get filter table index for MID             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableAddMsgID()
+ * ----------------------------------------------------
+ */
 int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableAddMsgID), MessageID);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableAddMsgID), FilterIndex);
-    return UT_DEFAULT_IMPL(DS_TableAddMsgID);
+    UT_GenStub_SetupReturnBuffer(DS_TableAddMsgID, int32);
+
+    UT_GenStub_AddParam(DS_TableAddMsgID, CFE_SB_MsgId_t, MessageID);
+    UT_GenStub_AddParam(DS_TableAddMsgID, int32, FilterIndex);
+
+    UT_GenStub_Execute(DS_TableAddMsgID, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableAddMsgID, int32);
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* DS_TableFindMsgID() - get filter table index for MID            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableCreateCDS()
+ * ----------------------------------------------------
+ */
+int32 DS_TableCreateCDS(void)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableCreateCDS, int32);
 
+    UT_GenStub_Execute(DS_TableCreateCDS, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableCreateCDS, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableCreateHash()
+ * ----------------------------------------------------
+ */
+void DS_TableCreateHash(void)
+{
+
+    UT_GenStub_Execute(DS_TableCreateHash, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableEntryUnused()
+ * ----------------------------------------------------
+ */
+bool DS_TableEntryUnused(const void *TableEntry, int32 BufferSize)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableEntryUnused, bool);
+
+    UT_GenStub_AddParam(DS_TableEntryUnused, const void *, TableEntry);
+    UT_GenStub_AddParam(DS_TableEntryUnused, int32, BufferSize);
+
+    UT_GenStub_Execute(DS_TableEntryUnused, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableEntryUnused, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableFindMsgID()
+ * ----------------------------------------------------
+ */
 int32 DS_TableFindMsgID(CFE_SB_MsgId_t MessageID)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(DS_TableFindMsgID), MessageID);
-    return UT_DEFAULT_IMPL(DS_TableFindMsgID);
+    UT_GenStub_SetupReturnBuffer(DS_TableFindMsgID, int32);
+
+    UT_GenStub_AddParam(DS_TableFindMsgID, CFE_SB_MsgId_t, MessageID);
+
+    UT_GenStub_Execute(DS_TableFindMsgID, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableFindMsgID, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableHashFunction()
+ * ----------------------------------------------------
+ */
+uint32 DS_TableHashFunction(CFE_SB_MsgId_t MessageID)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableHashFunction, uint32);
+
+    UT_GenStub_AddParam(DS_TableHashFunction, CFE_SB_MsgId_t, MessageID);
+
+    UT_GenStub_Execute(DS_TableHashFunction, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableHashFunction, uint32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableInit()
+ * ----------------------------------------------------
+ */
+int32 DS_TableInit(void)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableInit, int32);
+
+    UT_GenStub_Execute(DS_TableInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableInit, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableManageDestFile()
+ * ----------------------------------------------------
+ */
+void DS_TableManageDestFile(void)
+{
+
+    UT_GenStub_Execute(DS_TableManageDestFile, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableManageFilter()
+ * ----------------------------------------------------
+ */
+void DS_TableManageFilter(void)
+{
+
+    UT_GenStub_Execute(DS_TableManageFilter, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableSubscribe()
+ * ----------------------------------------------------
+ */
+void DS_TableSubscribe(void)
+{
+
+    UT_GenStub_Execute(DS_TableSubscribe, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableUnsubscribe()
+ * ----------------------------------------------------
+ */
+void DS_TableUnsubscribe(void)
+{
+
+    UT_GenStub_Execute(DS_TableUnsubscribe, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableUpdateCDS()
+ * ----------------------------------------------------
+ */
+void DS_TableUpdateCDS(void)
+{
+
+    UT_GenStub_Execute(DS_TableUpdateCDS, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyAge()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyAge(uint32 MaxFileAge)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyAge, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyAge, uint32, MaxFileAge);
+
+    UT_GenStub_Execute(DS_TableVerifyAge, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyAge, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyCount()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyCount(uint32 SequenceCount)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyCount, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyCount, uint32, SequenceCount);
+
+    UT_GenStub_Execute(DS_TableVerifyCount, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyCount, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyDestFile()
+ * ----------------------------------------------------
+ */
+int32 DS_TableVerifyDestFile(const void *TableData)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyDestFile, int32);
+
+    UT_GenStub_AddParam(DS_TableVerifyDestFile, const void *, TableData);
+
+    UT_GenStub_Execute(DS_TableVerifyDestFile, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyDestFile, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyDestFileEntry()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableIndex, int32 ErrorCount)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyDestFileEntry, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyDestFileEntry, DS_DestFileEntry_t *, DestFileEntry);
+    UT_GenStub_AddParam(DS_TableVerifyDestFileEntry, uint8, TableIndex);
+    UT_GenStub_AddParam(DS_TableVerifyDestFileEntry, int32, ErrorCount);
+
+    UT_GenStub_Execute(DS_TableVerifyDestFileEntry, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyDestFileEntry, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyFileIndex()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyFileIndex(uint16 FileTableIndex)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyFileIndex, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyFileIndex, uint16, FileTableIndex);
+
+    UT_GenStub_Execute(DS_TableVerifyFileIndex, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyFileIndex, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyFilter()
+ * ----------------------------------------------------
+ */
+int32 DS_TableVerifyFilter(const void *TableData)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyFilter, int32);
+
+    UT_GenStub_AddParam(DS_TableVerifyFilter, const void *, TableData);
+
+    UT_GenStub_Execute(DS_TableVerifyFilter, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyFilter, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyFilterEntry()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyFilterEntry(DS_PacketEntry_t *PacketEntry, int32 TableIndex, int32 ErrorCount)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyFilterEntry, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyFilterEntry, DS_PacketEntry_t *, PacketEntry);
+    UT_GenStub_AddParam(DS_TableVerifyFilterEntry, int32, TableIndex);
+    UT_GenStub_AddParam(DS_TableVerifyFilterEntry, int32, ErrorCount);
+
+    UT_GenStub_Execute(DS_TableVerifyFilterEntry, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyFilterEntry, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyParms()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyParms(uint16 Algorithm_N, uint16 Algorithm_X, uint16 Algorithm_O)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyParms, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyParms, uint16, Algorithm_N);
+    UT_GenStub_AddParam(DS_TableVerifyParms, uint16, Algorithm_X);
+    UT_GenStub_AddParam(DS_TableVerifyParms, uint16, Algorithm_O);
+
+    UT_GenStub_Execute(DS_TableVerifyParms, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyParms, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifySize()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifySize(uint32 MaxFileSize)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifySize, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifySize, uint32, MaxFileSize);
+
+    UT_GenStub_Execute(DS_TableVerifySize, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifySize, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyState()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyState(uint16 EnableState)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyState, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyState, uint16, EnableState);
+
+    UT_GenStub_Execute(DS_TableVerifyState, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyState, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for DS_TableVerifyType()
+ * ----------------------------------------------------
+ */
+bool DS_TableVerifyType(uint16 TimeVsCount)
+{
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyType, bool);
+
+    UT_GenStub_AddParam(DS_TableVerifyType, uint16, TimeVsCount);
+
+    UT_GenStub_Execute(DS_TableVerifyType, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(DS_TableVerifyType, bool);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Separate the global variables into separate stub source units, then re-run the stub generator for all internal APIs. The committed result here is the exact output of the tool, unmodified.

This eases future maintenance, when an internal API changes one just needs to re-run the stub generator tool to update it.

Fixes #100

**Testing performed**
Build and run all tests.  (Affects UT only)

**Expected behavior changes**
Stubs easier to maintain going forward.  No changes in behavior.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
