### PR TITLE
Fix #92, Use payload sub-struct in all messages

### DIFF
--- a/docs/dox_src/cfs_ds.dox
+++ b/docs/dox_src/cfs_ds.dox
@@ -50,15 +50,15 @@
 
 /**
   \page cfsdsintro CFS Data Storage Introduction
-	
+
   <H2> Scope </H2>
 
   This document provides a complete specification for the commands and telemetry associated
-  with the CFS Data Storage (DS) application software.  The document is intended primarily 
-  for users of the software (operations personal, test engineers, and maintenance personnel).  
-  The last section of the document, the deployment guide section, is intended for mission 
-  developers when deploying and configuring the application software for a mission 
-  flight software build environment. 
+  with the CFS Data Storage (DS) application software.  The document is intended primarily
+  for users of the software (operations personal, test engineers, and maintenance personnel).
+  The last section of the document, the deployment guide section, is intended for mission
+  developers when deploying and configuring the application software for a mission
+  flight software build environment.
 
   \ref cfsdsversion
 
@@ -108,7 +108,7 @@
 
 /**
   \page cfsdsovr CFS Data Storage Overview
-	
+
   The CFS DS application is responsible for storing messages in files. These files are generally stored on a storage device such as a solid state recorder but they could be stored on any file system. Another application such as CFDP must be used in order to transfer the files created by DS to the ground. The DS software context diagram is shown in Figure DS-1.
 
   \image html CFS_DS_Context.jpg "Figure DS-1: Software Context Diagram"
@@ -124,9 +124,9 @@
 
 /**
   \page cfsdsopr CFS Data Storage Operation
-  
+
   When DS receives a message that passes the filtering algorithm, the message is stored in a file or files based upon the File Table information for that message ID. Once a message is stored, the DS Housekeeping packet displays information about the open file. Each houskeeping cycle, DS evaluates the open files to determine if their age has been exceeded. If this determination is true, the file is closed by the DS application. Also, each time a message is to be stored, DS determines if the message will fit in the open file. If the determination is false, the open file will be closed and a new file created containing the message. A minimum of one message will be stored each file.
-   
+
   <h2>Filtering</h2>
   Filtering is based upon message IDs. The Filter Table determines what messages DS will store. The DS application supports two types of filtering:
  <ol><li>Sequence number based filtering</li>
@@ -141,7 +141,7 @@
 
 /**
   \page cfsdsdg  CFS Data Storage Deployment Guide
-  
+
   To integrate the DS application, follow the CFS App Integration Guide.
   Also, be sure to set up the configuration parameters and message IDs for
   the platform.
@@ -150,7 +150,7 @@
   If the DS_MOVE_FILES configuration parameter is set to TRUE, the telemetry
   database, Destination File table load images and the File Table display page
   require changes. The Destination File Table rdl file uses the DS_MOVE_FILES
-  definition in the ds_platform_cfg.h file. However, in order to get the 
+  definition in the ds_platform_cfg.h file. However, in order to get the
   required parameter included in telemetry, this configuration parameter must be
   set to 1 rather than TRUE. The table images must include this parameter in
   order to load successfully and the display page must be modified to display
@@ -160,25 +160,25 @@
 /**
   \page cfsdstbl CFS Data Storage Table Definitions
 
-  <H2>Destination File Table</H2> 
+  <H2>Destination File Table</H2>
 
-  The Destination File Table is defined by #DS_DestFileTable_t. This table 
+  The Destination File Table is defined by #DS_DestFileTable_t. This table
   contains a description and #DS_DEST_FILE_CNT entries. Each entry is defined by
   #DS_DestFileEntry_t.
 
-  <H2>Filter Table</H2> 
+  <H2>Filter Table</H2>
 
-  The Filter Table is defined by #DS_FilterTable_t. This table contains a 
+  The Filter Table is defined by #DS_FilterTable_t. This table contains a
   description and #DS_PACKETS_IN_FILTER_TABLE entries. Each entry is defined by
   #DS_PacketEntry_t. Each Packet entry contains the Message ID for DS to store
   and #DS_FILTERS_PER_PACKET entries defined by #DS_FilterParms_t.
 
-  The Data Storage (DS) application attempts to load the File and Filter Tables from #DS_DEF_DEST_FILENAME and #DS_DEF_FILTER_FILENAME upon startup. 
-  If the load fails for either of these tables, DS will still start in the mode of operation as defined by the #DS_DEF_ENABLE_STATE configuration 
-  parameter.  If this configuration parameter is set to ENABLED mode and either the File and/or Filter Table failed to load, DS will not store any 
-  messages until both tables are loaded with valid data. This can be accomplished by using the cFE Table Services commands after creating a table 
-  load image file and uploading it to the spacecraft's file system.  Until both tables are loaded with valid data, DS will increment the 
-  #DS_HkPacket_t.IgnoredPktCounter for each received packet that is discarded. 
+  The Data Storage (DS) application attempts to load the File and Filter Tables from #DS_DEF_DEST_FILENAME and #DS_DEF_FILTER_FILENAME upon startup.
+  If the load fails for either of these tables, DS will still start in the mode of operation as defined by the #DS_DEF_ENABLE_STATE configuration
+  parameter.  If this configuration parameter is set to ENABLED mode and either the File and/or Filter Table failed to load, DS will not store any
+  messages until both tables are loaded with valid data. This can be accomplished by using the cFE Table Services commands after creating a table
+  load image file and uploading it to the spacecraft's file system.  Until both tables are loaded with valid data, DS will increment the
+  #DS_HkTlm_Payload_t.IgnoredPktCounter for each received packet that is discarded.
 **/
 
 /**
@@ -194,12 +194,12 @@
   </B> <BR> <BR> <I>
      The Message IDs to be stored are specified in the Filter Table. To determine what these are, you must dump the filter table. This can be done by displaying the Filter Table display page and clicking the Refresh button.
   </I>
-  
+
   <B> (Q) Where are my files being stored?
   </B> <BR> <BR> <I>
      The locations of the files are determined by the File Table entry that the message ID is associated with. The Filter table indicates what File index is being used to store that message IDs data. To trace the message ID to the File entry, both tables must be dumped. This can be done by displaying the File and Filter Table display pages and clicking the Refresh buttons on each page.
   </I>
-  
+
   <B> (Q) How are my files named?
   </B> <BR> <BR> <I>
      The files are named as follows:<BR><BR>

--- a/fsw/inc/ds_msg.h
+++ b/fsw/inc/ds_msg.h
@@ -53,6 +53,17 @@ typedef struct
 } DS_ResetCmd_t;
 
 /**
+ *  \brief Payload containing Ena/Dis State
+ *
+ *  Used with #DS_AppStateCmd_t
+ */
+typedef struct
+{
+    uint16 EnableState; /**< \brief Application enable/disable state */
+    uint16 Padding;     /**< \brief Structure Padding on 32-bit boundaries */
+} DS_AppState_Payload_t;
+
+/**
  *  \brief Set Ena/Dis State For DS Application
  *
  *  For command details see #DS_SET_APP_STATE_CC
@@ -61,9 +72,21 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 EnableState; /**< \brief Application enable/disable state */
-    uint16 Padding;     /**< \brief Structure Padding on 32-bit boundaries */
+    DS_AppState_Payload_t Payload;
 } DS_AppStateCmd_t;
+
+/**
+ *  \brief Set File Selection Payload
+ *
+ *  Used with #DS_FilterFileCmd_t
+ */
+typedef struct
+{
+    CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
+                                   \details DS defines Message ID zero to be unused */
+    uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
+    uint16 FileTableIndex;    /**< \brief Index into Destination File Table */
+} DS_FilterFile_Payload_t;
 
 /**
  *  \brief Set File Selection For Packet Filter Table Entry
@@ -74,11 +97,21 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_FilterFile_Payload_t Payload;
+} DS_FilterFileCmd_t;
+
+/**
+ *  \brief Set Filter Type Payload
+ *
+ *  Used with #DS_FilterTypeCmd_t
+ */
+typedef struct
+{
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
     uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
-    uint16 FileTableIndex;    /**< \brief Index into Destination File Table */
-} DS_FilterFileCmd_t;
+    uint16 FilterType;        /**< \brief Filter type (packet count or time) */
+} DS_FilterType_Payload_t;
 
 /**
  *  \brief Set Filter Type For Packet Filter Table Entry
@@ -89,11 +122,23 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_FilterType_Payload_t Payload;
+} DS_FilterTypeCmd_t;
+
+/**
+ *  \brief Set Filter Parameters Payload
+ *
+ *  Used with #DS_FilterParmsCmd_t
+ */
+typedef struct
+{
     CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
                                    \details DS defines Message ID zero to be unused */
     uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
-    uint16 FilterType;        /**< \brief Filter type (packet count or time) */
-} DS_FilterTypeCmd_t;
+    uint16 Algorithm_N;       /**< \brief Algorithm value N (pass this many) */
+    uint16 Algorithm_X;       /**< \brief Algorithm value X (out of this many) */
+    uint16 Algorithm_O;       /**< \brief Algorithm value O (at this offset) */
+} DS_FilterParms_Payload_t;
 
 /**
  *  \brief Set Filter Parameters For Packet Filter Table Entry
@@ -104,13 +149,19 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    CFE_SB_MsgId_t MessageID; /**< \brief Message ID of existing entry in Packet Filter Table
-                                   \details DS defines Message ID zero to be unused */
-    uint16 FilterParmsIndex;  /**< \brief Index into Filter Parms Array */
-    uint16 Algorithm_N;       /**< \brief Algorithm value N (pass this many) */
-    uint16 Algorithm_X;       /**< \brief Algorithm value X (out of this many) */
-    uint16 Algorithm_O;       /**< \brief Algorithm value O (at this offset) */
+    DS_FilterParms_Payload_t Payload;
 } DS_FilterParmsCmd_t;
+
+/**
+ *  \brief Set Filename Type Payload
+ *
+ *  Used with #DS_DestTypeCmd_t
+ */
+typedef struct
+{
+    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
+    uint16 FileNameType;   /**< \brief Filename type - count vs time */
+} DS_DestType_Payload_t;
 
 /**
  *  \brief Set Filename Type For Destination File Table Entry
@@ -121,9 +172,22 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
-    uint16 FileNameType;   /**< \brief Filename type - count vs time */
+    DS_DestType_Payload_t Payload;
 } DS_DestTypeCmd_t;
+
+/**
+ *  \brief Set Ena/Dis State For Destination File Table Entry
+ *  \brief Set Filename Type Payload
+ *
+ *  Used with #DS_DestTypeCmd_t
+ *
+ *  For command details see #DS_SET_DEST_STATE_CC
+ */
+typedef struct
+{
+    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
+    uint16 EnableState;    /**< \brief File enable/disable state */
+} DS_DestState_Payload_t;
 
 /**
  *  \brief Set Ena/Dis State For Destination File Table Entry
@@ -134,9 +198,20 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
-    uint16 EnableState;    /**< \brief File enable/disable state */
+    DS_DestState_Payload_t Payload;
 } DS_DestStateCmd_t;
+
+/**
+ *  \brief Set Path Portion Of Filename For Destination File Payload
+ *
+ *  Used with #DS_DestPathCmd_t
+ */
+typedef struct
+{
+    uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
+    uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
+    char   Pathname[DS_PATHNAME_BUFSIZE]; /**< \brief Path portion of filename */
+} DS_DestPath_Payload_t;
 
 /**
  *  \brief Set Path Portion Of Filename For Destination File Table Entry
@@ -147,10 +222,20 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_DestPath_Payload_t Payload;
+} DS_DestPathCmd_t;
+
+/**
+ *  \brief Set Base Portion Of Filename For Destination File Payload
+ *
+ *  Used with #DS_DestBaseCmd_t
+ */
+typedef struct
+{
     uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
     uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
-    char   Pathname[DS_PATHNAME_BUFSIZE]; /**< \brief Path portion of filename */
-} DS_DestPathCmd_t;
+    char   Basename[DS_BASENAME_BUFSIZE]; /**< \brief Base portion of filename */
+} DS_DestBase_Payload_t;
 
 /**
  *  \brief Set Base Portion Of Filename For Destination File Table Entry
@@ -161,10 +246,20 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 FileTableIndex;                /**< \brief Index into Destination File Table */
-    uint16 Padding;                       /**< \brief Structure Padding on 32-bit boundaries */
-    char   Basename[DS_BASENAME_BUFSIZE]; /**< \brief Base portion of filename */
+    DS_DestBase_Payload_t Payload;
 } DS_DestBaseCmd_t;
+
+/**
+ *  \brief Set Extension Portion Of Filename For Destination File Payload
+ *
+ *  Used with #DS_DestExtCmd_t
+ */
+typedef struct
+{
+    uint16 FileTableIndex;                  /**< \brief Index into Destination File Table */
+    uint16 Padding;                         /**< \brief Structure Padding on 32-bit boundaries */
+    char   Extension[DS_EXTENSION_BUFSIZE]; /**< \brief Extension portion of filename */
+} DS_DestExt_Payload_t;
 
 /**
  *  \brief Set Extension Portion Of Filename For Destination File Table Entry
@@ -175,10 +270,22 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 FileTableIndex;                  /**< \brief Index into Destination File Table */
-    uint16 Padding;                         /**< \brief Structure Padding on 32-bit boundaries */
-    char   Extension[DS_EXTENSION_BUFSIZE]; /**< \brief Extension portion of filename */
+    DS_DestExt_Payload_t Payload;
 } DS_DestExtCmd_t;
+
+/**
+ *  \brief Set Max File Size For Destination File Table Payload
+ *
+ *  Used with #DS_DestSizeCmd_t
+ *
+ *  For command details see #DS_SET_DEST_SIZE_CC
+ */
+typedef struct
+{
+    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
+    uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
+    uint32 MaxFileSize;    /**< \brief Max file size (bytes) before re-open */
+} DS_DestSize_Payload_t;
 
 /**
  *  \brief Set Max File Size For Destination File Table Entry
@@ -189,10 +296,21 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_DestSize_Payload_t Payload;
+} DS_DestSizeCmd_t;
+
+/**
+ *  \brief Set Max File Age For Destination File Table Payload
+ *
+ *  Used with #DS_DestAgeCmd_t
+ */
+typedef struct
+{
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
-    uint32 MaxFileSize;    /**< \brief Max file size (bytes) before re-open */
-} DS_DestSizeCmd_t;
+
+    uint32 MaxFileAge; /**< \brief Max file age (seconds) */
+} DS_DestAge_Payload_t;
 
 /**
  *  \brief Set Max File Age For Destination File Table Entry
@@ -203,11 +321,21 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_DestAge_Payload_t Payload;
+} DS_DestAgeCmd_t;
+
+/**
+ *  \brief Set Sequence Portion Of Filename For Destination File Table Payload
+ *
+ *  Used with #DS_DestCountCmd_t
+ */
+typedef struct
+{
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
 
-    uint32 MaxFileAge; /**< \brief Max file age (seconds) */
-} DS_DestAgeCmd_t;
+    uint32 SequenceCount; /**< \brief Sequence count portion of filename */
+} DS_DestCount_Payload_t;
 
 /**
  *  \brief Set Sequence Portion Of Filename For Destination File Table Entry
@@ -218,11 +346,19 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
+    DS_DestCount_Payload_t Payload;
+} DS_DestCountCmd_t;
+
+/**
+ *  \brief Close Destination File Payload
+ *
+ *  Used with #DS_CloseFileCmd_t
+ */
+typedef struct
+{
     uint16 FileTableIndex; /**< \brief Index into Destination File Table */
     uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
-
-    uint32 SequenceCount; /**< \brief Sequence count portion of filename */
-} DS_DestCountCmd_t;
+} DS_CloseFile_Payload_t;
 
 /**
  *  \brief Close Destination File
@@ -233,8 +369,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    uint16 FileTableIndex; /**< \brief Index into Destination File Table */
-    uint16 Padding;        /**< \brief Structure Padding on 32-bit boundaries */
+    DS_CloseFile_Payload_t Payload;
 } DS_CloseFileCmd_t;
 
 /**
@@ -258,6 +393,18 @@ typedef struct
 } DS_GetFileInfoCmd_t;
 
 /**
+ *  \brief Message ID Payload
+ *
+ *  Used with #DS_AddMidCmd_t, #DS_RemoveMidCmd_t
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
+
+    CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
+} DS_AddRemoveMid_Payload_t;
+
+/**
  *  \brief Add Message ID To Packet Filter Table
  *
  *  For command details see #DS_ADD_MID_CC
@@ -266,7 +413,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
+    DS_AddRemoveMid_Payload_t Payload;
 } DS_AddMidCmd_t;
 
 /**
@@ -278,8 +425,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief cFE Software Bus command message header */
 
-    CFE_SB_MsgId_t MessageID; /**< \brief Message ID to add to Packet Filter Table */
-
+    DS_AddRemoveMid_Payload_t Payload;
 } DS_RemoveMidCmd_t;
 
 /**\}*/
@@ -289,13 +435,8 @@ typedef struct
  * \{
  */
 
-/**
- * \brief Application housekeeping packet
- */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
-
     uint8  CmdAcceptedCounter;                 /**< \brief Count of valid commands received */
     uint8  CmdRejectedCounter;                 /**< \brief Count of invalid commands received */
     uint8  DestTblLoadCounter;                 /**< \brief Count of destination file table loads */
@@ -319,6 +460,16 @@ typedef struct
     uint32 FilteredPktCounter;                 /**< \brief Count of packets discarded (failed filter test) */
     uint32 PassedPktCounter;                   /**< \brief Count of packets that passed filter test */
     char   FilterTblFilename[OS_MAX_PATH_LEN]; /**< \brief Name of filter table file */
+} DS_HkTlm_Payload_t;
+
+/**
+ * \brief Application housekeeping packet
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
+
+    DS_HkTlm_Payload_t Payload;
 } DS_HkPacket_t;
 
 /**
@@ -342,7 +493,7 @@ typedef struct
 {
     CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
 
-    DS_FileInfo_t FileInfo[DS_DEST_FILE_CNT]; /**< \brief Current state of destination files */
+    DS_FileInfo_t Payload[DS_DEST_FILE_CNT]; /**< \brief Current state of destination files */
 } DS_FileInfoPkt_t;
 
 /**
@@ -352,7 +503,7 @@ typedef struct
 {
     CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief cFE Software Bus telemetry message header */
 
-    DS_FileInfo_t FileInfo; /**< \brief Current state of destination file */
+    DS_FileInfo_t Payload; /**< \brief Current state of destination file */
 } DS_FileCompletePkt_t;
 
 /**

--- a/fsw/inc/ds_msgdefs.h
+++ b/fsw/inc/ds_msgdefs.h
@@ -42,7 +42,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_NOOP_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
@@ -50,7 +50,7 @@
  *       - Invalid command packet length
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_NOOP_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -69,7 +69,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will reset to zero
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will reset to zero
  *       - The #DS_RESET_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -77,7 +77,7 @@
  *       - Invalid command packet length
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_RESET_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -97,7 +97,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_ENADIS_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -106,7 +106,7 @@
  *       - Invalid enable/disable state selection
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_ENADIS_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -126,7 +126,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_FILE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -139,7 +139,7 @@
  *       - Cannot modify unused packet filter table entry
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_FILE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -159,7 +159,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_FTYPE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -172,7 +172,7 @@
  *       - Cannot modify unused packet filter table entry
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_FTYPE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -192,7 +192,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_PARMS_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -205,7 +205,7 @@
  *       - Cannot modify unused packet filter table entry
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_PARMS_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -225,7 +225,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_NTYPE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -236,7 +236,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_NTYPE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -256,7 +256,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_STATE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -267,7 +267,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_STATE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -287,7 +287,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_PATH_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -298,7 +298,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_PATH_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -318,7 +318,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_BASE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -329,7 +329,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_BASE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -349,7 +349,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_EXT_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -360,7 +360,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_EXT_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -380,7 +380,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_SIZE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -391,7 +391,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_SIZE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -411,7 +411,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_AGE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -422,7 +422,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_AGE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -442,7 +442,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_SEQ_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -453,7 +453,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_SEQ_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -472,7 +472,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_CLOSE_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -482,7 +482,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_CLOSE_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -501,7 +501,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_FileInfoPkt_t packet will be sent
  *
  *  \par Error Conditions
@@ -509,7 +509,7 @@
  *       - Invalid command packet length
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_GET_FILE_INFO_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -529,7 +529,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_ADD_MID_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -541,7 +541,7 @@
  *       - All packet filter table entries are already in use
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_ADD_MID_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -562,7 +562,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_CLOSE_ALL_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -571,7 +571,7 @@
  *       - Destination file table is not currently loaded
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_CLOSE_ALL_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality
@@ -591,7 +591,7 @@
  *
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdAcceptedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
  *       - The #DS_REMOVE_MID_CMD_EID debug event message will be sent
  *
  *  \par Error Conditions
@@ -602,7 +602,7 @@
  *       - Message ID does not exist in packet filter table
  *
  *       Evidence of failure may be found in the following telemetry:
- *       - #DS_HkPacket_t.CmdRejectedCounter will increment
+ *       - #DS_HkTlm_Payload_t.CmdRejectedCounter will increment
  *       - The #DS_REMOVE_MID_CMD_ERR_EID error event message will be sent
  *
  *  \par Criticality

--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -507,6 +507,8 @@ void DS_AppProcessHK(void)
     char           FilterTblName[CFE_MISSION_TBL_MAX_NAME_LENGTH] = {0};
     CFE_TBL_Info_t FilterTblInfo;
 
+    DS_HkTlm_Payload_t *PayloadPtr;
+
     memset(&HkPacket, 0, sizeof(HkPacket));
 
     /*
@@ -525,40 +527,43 @@ void DS_AppProcessHK(void)
     DS_TableManageDestFile();
     DS_TableManageFilter();
 
+    /* Get internal payload substructure */
+    PayloadPtr = &HkPacket.Payload;
+
     /*
     ** Copy application command counters to housekeeping telemetry packet...
     */
-    HkPacket.CmdAcceptedCounter = DS_AppData.CmdAcceptedCounter;
-    HkPacket.CmdRejectedCounter = DS_AppData.CmdRejectedCounter;
+    PayloadPtr->CmdAcceptedCounter = DS_AppData.CmdAcceptedCounter;
+    PayloadPtr->CmdRejectedCounter = DS_AppData.CmdRejectedCounter;
 
     /*
     ** Copy packet storage counters to housekeeping telemetry packet...
     */
-    HkPacket.DisabledPktCounter = DS_AppData.DisabledPktCounter;
-    HkPacket.IgnoredPktCounter  = DS_AppData.IgnoredPktCounter;
-    HkPacket.FilteredPktCounter = DS_AppData.FilteredPktCounter;
-    HkPacket.PassedPktCounter   = DS_AppData.PassedPktCounter;
+    PayloadPtr->DisabledPktCounter = DS_AppData.DisabledPktCounter;
+    PayloadPtr->IgnoredPktCounter  = DS_AppData.IgnoredPktCounter;
+    PayloadPtr->FilteredPktCounter = DS_AppData.FilteredPktCounter;
+    PayloadPtr->PassedPktCounter   = DS_AppData.PassedPktCounter;
 
     /*
     ** Copy file I/O counters to housekeeping telemetry packet...
     */
-    HkPacket.FileWriteCounter     = DS_AppData.FileWriteCounter;
-    HkPacket.FileWriteErrCounter  = DS_AppData.FileWriteErrCounter;
-    HkPacket.FileUpdateCounter    = DS_AppData.FileUpdateCounter;
-    HkPacket.FileUpdateErrCounter = DS_AppData.FileUpdateErrCounter;
+    PayloadPtr->FileWriteCounter     = DS_AppData.FileWriteCounter;
+    PayloadPtr->FileWriteErrCounter  = DS_AppData.FileWriteErrCounter;
+    PayloadPtr->FileUpdateCounter    = DS_AppData.FileUpdateCounter;
+    PayloadPtr->FileUpdateErrCounter = DS_AppData.FileUpdateErrCounter;
 
     /*
     ** Copy configuration table counters to housekeeping telemetry packet...
     */
-    HkPacket.DestTblLoadCounter   = DS_AppData.DestTblLoadCounter;
-    HkPacket.DestTblErrCounter    = DS_AppData.DestTblErrCounter;
-    HkPacket.FilterTblLoadCounter = DS_AppData.FilterTblLoadCounter;
-    HkPacket.FilterTblErrCounter  = DS_AppData.FilterTblErrCounter;
+    PayloadPtr->DestTblLoadCounter   = DS_AppData.DestTblLoadCounter;
+    PayloadPtr->DestTblErrCounter    = DS_AppData.DestTblErrCounter;
+    PayloadPtr->FilterTblLoadCounter = DS_AppData.FilterTblLoadCounter;
+    PayloadPtr->FilterTblErrCounter  = DS_AppData.FilterTblErrCounter;
 
     /*
     ** Copy app enable/disable state to housekeeping telemetry packet...
     */
-    HkPacket.AppEnableState = DS_AppData.AppEnableState;
+    PayloadPtr->AppEnableState = DS_AppData.AppEnableState;
 
     /*
     ** Compute file growth rate from number of bytes since last HK request...
@@ -576,8 +581,8 @@ void DS_AppProcessHK(void)
         Status = CFE_TBL_GetInfo(&FilterTblInfo, FilterTblName);
         if (Status == CFE_SUCCESS)
         {
-            strncpy(HkPacket.FilterTblFilename, FilterTblInfo.LastFileLoaded, OS_MAX_PATH_LEN - 1);
-            HkPacket.FilterTblFilename[OS_MAX_PATH_LEN - 1] = '\0';
+            strncpy(PayloadPtr->FilterTblFilename, FilterTblInfo.LastFileLoaded, OS_MAX_PATH_LEN - 1);
+            PayloadPtr->FilterTblFilename[OS_MAX_PATH_LEN - 1] = '\0';
         }
 
         else
@@ -587,7 +592,7 @@ void DS_AppProcessHK(void)
             CFE_EVS_SendEvent(DS_APPHK_FILTER_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid filter tbl name in DS_AppProcessHK. Name=%s, Err=0x%08X", FilterTblName, Status);
 
-            memset(HkPacket.FilterTblFilename, 0, sizeof(HkPacket.FilterTblFilename));
+            memset(PayloadPtr->FilterTblFilename, 0, sizeof(PayloadPtr->FilterTblFilename));
         }
     }
     else
@@ -597,7 +602,7 @@ void DS_AppProcessHK(void)
         CFE_EVS_SendEvent(DS_APPHK_FILTER_TBL_PRINT_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Filter tbl name copy fail in DS_AppProcessHK. Err=%d", (int)Status);
 
-        memset(HkPacket.FilterTblFilename, 0, sizeof(HkPacket.FilterTblFilename));
+        memset(PayloadPtr->FilterTblFilename, 0, sizeof(PayloadPtr->FilterTblFilename));
     }
 
     /*

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -40,6 +40,14 @@
 
 #include <stdio.h>
 
+/**
+ * \brief Internal Macro to access the internal payload structure of a message
+ *
+ * This is done as a macro so it can be applied consistently to all
+ * message processing functions, based on the way DS defines its messages.
+ */
+#define DS_GET_CMD_PAYLOAD(ptr, type) (&((const type *)(ptr))->Payload)
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* NOOP command                                                    */
@@ -144,9 +152,12 @@ void DS_CmdReset(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_AppStateCmd_t *DS_AppStateCmd = (DS_AppStateCmd_t *)BufPtr;
-    size_t            ActualLength   = 0;
-    size_t            ExpectedLength = sizeof(DS_AppStateCmd_t);
+    const DS_AppState_Payload_t *DS_AppStateCmd;
+
+    size_t ActualLength   = 0;
+    size_t ExpectedLength = sizeof(DS_AppStateCmd_t);
+
+    DS_AppStateCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_AppStateCmd_t);
 
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
@@ -198,13 +209,15 @@ void DS_CmdSetAppState(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_FilterFileCmd_t *DS_FilterFileCmd = (DS_FilterFileCmd_t *)BufPtr;
-    size_t              ActualLength     = 0;
-    size_t              ExpectedLength   = sizeof(DS_FilterFileCmd_t);
-    DS_PacketEntry_t *  pPacketEntry     = NULL;
-    DS_FilterParms_t *  pFilterParms     = NULL;
-    int32               FilterTableIndex = 0;
+    const DS_FilterFile_Payload_t *DS_FilterFileCmd;
 
+    size_t            ActualLength     = 0;
+    size_t            ExpectedLength   = sizeof(DS_FilterFileCmd_t);
+    DS_PacketEntry_t *pPacketEntry     = NULL;
+    DS_FilterParms_t *pFilterParms     = NULL;
+    int32             FilterTableIndex = 0;
+
+    DS_FilterFileCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_FilterFileCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -311,12 +324,15 @@ void DS_CmdSetFilterFile(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_FilterTypeCmd_t *DS_FilterTypeCmd = (DS_FilterTypeCmd_t *)BufPtr;
-    size_t              ActualLength     = 0;
-    size_t              ExpectedLength   = sizeof(DS_FilterTypeCmd_t);
-    DS_PacketEntry_t *  pPacketEntry     = NULL;
-    DS_FilterParms_t *  pFilterParms     = NULL;
-    int32               FilterTableIndex = 0;
+    const DS_FilterType_Payload_t *DS_FilterTypeCmd;
+
+    size_t            ActualLength     = 0;
+    size_t            ExpectedLength   = sizeof(DS_FilterTypeCmd_t);
+    DS_PacketEntry_t *pPacketEntry     = NULL;
+    DS_FilterParms_t *pFilterParms     = NULL;
+    int32             FilterTableIndex = 0;
+
+    DS_FilterTypeCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_FilterTypeCmd_t);
 
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
@@ -424,13 +440,15 @@ void DS_CmdSetFilterType(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_FilterParmsCmd_t *DS_FilterParmsCmd = (DS_FilterParmsCmd_t *)BufPtr;
-    size_t               ActualLength      = 0;
-    size_t               ExpectedLength    = sizeof(DS_FilterParmsCmd_t);
-    DS_PacketEntry_t *   pPacketEntry      = NULL;
-    DS_FilterParms_t *   pFilterParms      = NULL;
-    int32                FilterTableIndex  = 0;
+    const DS_FilterParms_Payload_t *DS_FilterParmsCmd;
 
+    size_t            ActualLength     = 0;
+    size_t            ExpectedLength   = sizeof(DS_FilterParmsCmd_t);
+    DS_PacketEntry_t *pPacketEntry     = NULL;
+    DS_FilterParms_t *pFilterParms     = NULL;
+    int32             FilterTableIndex = 0;
+
+    DS_FilterParmsCmd = &((const DS_FilterParmsCmd_t *)BufPtr)->Payload;
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -542,11 +560,13 @@ void DS_CmdSetFilterParms(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestTypeCmd_t *  DS_DestTypeCmd = (DS_DestTypeCmd_t *)BufPtr;
+    const DS_DestType_Payload_t *DS_DestTypeCmd;
+
     size_t              ActualLength   = 0;
     size_t              ExpectedLength = sizeof(DS_DestTypeCmd_t);
     DS_DestFileEntry_t *pDest          = NULL;
 
+    DS_DestTypeCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestTypeCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -619,10 +639,12 @@ void DS_CmdSetDestType(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestStateCmd_t *DS_DestStateCmd = (DS_DestStateCmd_t *)BufPtr;
-    size_t             ActualLength    = 0;
-    size_t             ExpectedLength  = sizeof(DS_DestStateCmd_t);
+    const DS_DestState_Payload_t *DS_DestStateCmd;
 
+    size_t ActualLength   = 0;
+    size_t ExpectedLength = sizeof(DS_DestStateCmd_t);
+
+    DS_DestStateCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestStateCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -695,11 +717,13 @@ void DS_CmdSetDestState(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestPathCmd_t *  DS_DestPathCmd = (DS_DestPathCmd_t *)BufPtr;
+    const DS_DestPath_Payload_t *DS_DestPathCmd;
+
     size_t              ActualLength   = 0;
     size_t              ExpectedLength = sizeof(DS_DestPathCmd_t);
     DS_DestFileEntry_t *pDest          = NULL;
 
+    DS_DestPathCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestPathCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -763,11 +787,12 @@ void DS_CmdSetDestPath(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestBaseCmd_t *  DS_DestBaseCmd = (DS_DestBaseCmd_t *)BufPtr;
-    size_t              ActualLength   = 0;
-    size_t              ExpectedLength = sizeof(DS_DestBaseCmd_t);
-    DS_DestFileEntry_t *pDest          = NULL;
+    const DS_DestBase_Payload_t *DS_DestBaseCmd;
+    size_t                       ActualLength   = 0;
+    size_t                       ExpectedLength = sizeof(DS_DestBaseCmd_t);
+    DS_DestFileEntry_t *         pDest          = NULL;
 
+    DS_DestBaseCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestBaseCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -831,11 +856,12 @@ void DS_CmdSetDestBase(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestExtCmd_t *   DS_DestExtCmd  = (DS_DestExtCmd_t *)BufPtr;
-    size_t              ActualLength   = 0;
-    size_t              ExpectedLength = sizeof(DS_DestExtCmd_t);
-    DS_DestFileEntry_t *pDest          = NULL;
+    const DS_DestExt_Payload_t *DS_DestExtCmd;
+    size_t                      ActualLength   = 0;
+    size_t                      ExpectedLength = sizeof(DS_DestExtCmd_t);
+    DS_DestFileEntry_t *        pDest          = NULL;
 
+    DS_DestExtCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestExtCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -899,11 +925,13 @@ void DS_CmdSetDestExt(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestSizeCmd_t *  DS_DestSizeCmd = (DS_DestSizeCmd_t *)BufPtr;
+    const DS_DestSize_Payload_t *DS_DestSizeCmd;
+
     size_t              ActualLength   = 0;
     size_t              ExpectedLength = sizeof(DS_DestSizeCmd_t);
     DS_DestFileEntry_t *pDest          = NULL;
 
+    DS_DestSizeCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestSizeCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -976,11 +1004,13 @@ void DS_CmdSetDestSize(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestAgeCmd_t *   DS_DestAgeCmd  = (DS_DestAgeCmd_t *)BufPtr;
+    const DS_DestAge_Payload_t *DS_DestAgeCmd;
+
     size_t              ActualLength   = 0;
     size_t              ExpectedLength = sizeof(DS_DestAgeCmd_t);
     DS_DestFileEntry_t *pDest          = NULL;
 
+    DS_DestAgeCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestAgeCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -1053,12 +1083,13 @@ void DS_CmdSetDestAge(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_DestCountCmd_t * DS_DestCountCmd = (DS_DestCountCmd_t *)BufPtr;
-    size_t              ActualLength    = 0;
-    size_t              ExpectedLength  = sizeof(DS_DestCountCmd_t);
-    DS_AppFileStatus_t *FileStatus      = NULL;
-    DS_DestFileEntry_t *DestFile        = NULL;
+    const DS_DestCount_Payload_t *DS_DestCountCmd;
+    size_t                        ActualLength   = 0;
+    size_t                        ExpectedLength = sizeof(DS_DestCountCmd_t);
+    DS_AppFileStatus_t *          FileStatus     = NULL;
+    DS_DestFileEntry_t *          DestFile       = NULL;
 
+    DS_DestCountCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_DestCountCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -1143,10 +1174,11 @@ void DS_CmdSetDestCount(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdCloseFile(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_CloseFileCmd_t *DS_CloseFileCmd = (DS_CloseFileCmd_t *)BufPtr;
-    size_t             ActualLength    = 0;
-    size_t             ExpectedLength  = sizeof(DS_CloseFileCmd_t);
+    const DS_CloseFile_Payload_t *DS_CloseFileCmd;
+    size_t                        ActualLength   = 0;
+    size_t                        ExpectedLength = sizeof(DS_CloseFileCmd_t);
 
+    DS_CloseFileCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_CloseFileCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -1243,6 +1275,7 @@ void DS_CmdCloseAll(const CFE_SB_Buffer_t *BufPtr)
 void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
 {
     DS_FileInfoPkt_t DS_FileInfoPkt;
+    DS_FileInfo_t *  FileInfoPtr;
     size_t           ActualLength   = 0;
     size_t           ExpectedLength = sizeof(DS_GetFileInfoCmd_t);
     int32            i              = 0;
@@ -1280,32 +1313,34 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
         */
         for (i = 0; i < DS_DEST_FILE_CNT; i++)
         {
+            FileInfoPtr = &DS_FileInfoPkt.Payload[i];
+
             /*
             ** Set file age and size...
             */
-            DS_FileInfoPkt.FileInfo[i].FileAge  = DS_AppData.FileStatus[i].FileAge;
-            DS_FileInfoPkt.FileInfo[i].FileSize = DS_AppData.FileStatus[i].FileSize;
+            FileInfoPtr->FileAge  = DS_AppData.FileStatus[i].FileAge;
+            FileInfoPtr->FileSize = DS_AppData.FileStatus[i].FileSize;
 
             /*
             ** Set file growth rate (computed when process last HK request)...
             */
-            DS_FileInfoPkt.FileInfo[i].FileRate = DS_AppData.FileStatus[i].FileRate;
+            FileInfoPtr->FileRate = DS_AppData.FileStatus[i].FileRate;
 
             /*
             ** Set current filename sequence count...
             */
-            DS_FileInfoPkt.FileInfo[i].SequenceCount = DS_AppData.FileStatus[i].FileCount;
+            FileInfoPtr->SequenceCount = DS_AppData.FileStatus[i].FileCount;
 
             /*
             ** Set file enable/disable state...
             */
             if (DS_AppData.DestFileTblPtr == (DS_DestFileTable_t *)NULL)
             {
-                DS_FileInfoPkt.FileInfo[i].EnableState = DS_DISABLED;
+                FileInfoPtr->EnableState = DS_DISABLED;
             }
             else
             {
-                DS_FileInfoPkt.FileInfo[i].EnableState = DS_AppData.FileStatus[i].FileState;
+                FileInfoPtr->EnableState = DS_AppData.FileStatus[i].FileState;
             }
 
             /*
@@ -1313,17 +1348,16 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
             */
             if (!OS_ObjectIdDefined(DS_AppData.FileStatus[i].FileHandle))
             {
-                DS_FileInfoPkt.FileInfo[i].OpenState = DS_CLOSED;
+                FileInfoPtr->OpenState = DS_CLOSED;
             }
             else
             {
-                DS_FileInfoPkt.FileInfo[i].OpenState = DS_OPEN;
+                FileInfoPtr->OpenState = DS_OPEN;
 
                 /*
                 ** Set current open filename...
                 */
-                strncpy(DS_FileInfoPkt.FileInfo[i].FileName, DS_AppData.FileStatus[i].FileName,
-                        sizeof(DS_FileInfoPkt.FileInfo[i].FileName));
+                strncpy(FileInfoPtr->FileName, DS_AppData.FileStatus[i].FileName, sizeof(FileInfoPtr->FileName));
             }
         }
 
@@ -1343,15 +1377,16 @@ void DS_CmdGetFileInfo(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_AddMidCmd_t *  DS_AddMidCmd     = (DS_AddMidCmd_t *)BufPtr;
-    size_t            ActualLength     = 0;
-    size_t            ExpectedLength   = sizeof(DS_AddMidCmd_t);
-    DS_PacketEntry_t *pPacketEntry     = NULL;
-    DS_FilterParms_t *pFilterParms     = NULL;
-    int32             FilterTableIndex = 0;
-    int32             HashTableIndex   = 0;
-    int32             i                = 0;
+    const DS_AddRemoveMid_Payload_t *DS_AddMidCmd;
+    size_t                           ActualLength     = 0;
+    size_t                           ExpectedLength   = sizeof(DS_AddMidCmd_t);
+    DS_PacketEntry_t *               pPacketEntry     = NULL;
+    DS_FilterParms_t *               pFilterParms     = NULL;
+    int32                            FilterTableIndex = 0;
+    int32                            HashTableIndex   = 0;
+    int32                            i                = 0;
 
+    DS_AddMidCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_AddMidCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
 
     if (ExpectedLength != ActualLength)
@@ -1454,15 +1489,17 @@ void DS_CmdAddMID(const CFE_SB_Buffer_t *BufPtr)
 
 void DS_CmdRemoveMID(const CFE_SB_Buffer_t *BufPtr)
 {
-    DS_RemoveMidCmd_t *DS_RemoveMidCmd  = (DS_RemoveMidCmd_t *)BufPtr;
-    size_t             ActualLength     = 0;
-    size_t             ExpectedLength   = sizeof(DS_RemoveMidCmd_t);
-    DS_PacketEntry_t * pPacketEntry     = NULL;
-    DS_FilterParms_t * pFilterParms     = NULL;
-    int32              FilterTableIndex = 0;
-    int32              HashTableIndex   = 0;
-    int32              i                = 0;
+    const DS_AddRemoveMid_Payload_t *DS_RemoveMidCmd;
 
+    size_t            ActualLength     = 0;
+    size_t            ExpectedLength   = sizeof(DS_RemoveMidCmd_t);
+    DS_PacketEntry_t *pPacketEntry     = NULL;
+    DS_FilterParms_t *pFilterParms     = NULL;
+    int32             FilterTableIndex = 0;
+    int32             HashTableIndex   = 0;
+    int32             i                = 0;
+
+    DS_RemoveMidCmd = DS_GET_CMD_PAYLOAD(BufPtr, DS_RemoveMidCmd_t);
     CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
     FilterTableIndex = DS_TableFindMsgID(DS_RemoveMidCmd->MessageID);
 

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -972,7 +972,7 @@ void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
     {
         CFE_MSG_Init(CFE_MSG_PTR(PktBuf->Pkt.TelemetryHeader), CFE_SB_ValueToMsgId(DS_COMP_TLM_MID), sizeof(*PktBuf));
 
-        FileInfo = &PktBuf->Pkt.FileInfo;
+        FileInfo = &PktBuf->Pkt.Payload;
 
         /*
         ** Set file age and size...

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -208,6 +208,7 @@ void DS_CmdSetAppState_Test_Nominal(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "APP STATE command: state = %%d");
+    DS_AppState_Payload_t *CmdPayload = &UT_CmdBuf.AppStateCmd.Payload;
 
     size_t            forced_Size    = sizeof(DS_AppStateCmd_t);
     CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
@@ -217,7 +218,7 @@ void DS_CmdSetAppState_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &forced_CmdCode, sizeof(forced_CmdCode), false);
 
-    UT_CmdBuf.AppStateCmd.EnableState = true;
+    CmdPayload->EnableState = true;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyState), true);
 
@@ -246,9 +247,10 @@ void DS_CmdSetAppState_Test_Nominal(void)
 
 void DS_CmdSetAppState_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_AppStateCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_APP_STATE_CC;
+    size_t                 forced_Size    = sizeof(DS_AppStateCmd_t) + 1;
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_APP_STATE_CC;
+    DS_AppState_Payload_t *CmdPayload     = &UT_CmdBuf.AppStateCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -259,7 +261,7 @@ void DS_CmdSetAppState_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid APP STATE command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.AppStateCmd.EnableState = true;
+    CmdPayload->EnableState = true;
 
     /* Execute the function being tested */
     DS_CmdSetAppState(&UT_CmdBuf.Buf);
@@ -281,9 +283,10 @@ void DS_CmdSetAppState_Test_InvalidCommandLength(void)
 
 void DS_CmdSetAppState_Test_InvalidAppState(void)
 {
-    size_t            forced_Size    = sizeof(DS_AppStateCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_APP_STATE_CC;
+    size_t                 forced_Size    = sizeof(DS_AppStateCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_APP_STATE_CC;
+    DS_AppState_Payload_t *CmdPayload     = &UT_CmdBuf.AppStateCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -293,7 +296,7 @@ void DS_CmdSetAppState_Test_InvalidAppState(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Invalid APP STATE command arg: app state = %%d");
 
-    UT_CmdBuf.AppStateCmd.EnableState = 99;
+    CmdPayload->EnableState = 99;
 
     /* Execute the function being tested */
     DS_CmdSetAppState(&UT_CmdBuf.Buf);
@@ -317,10 +320,11 @@ void DS_CmdSetFilterFile_Test_Nominal(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size             = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID            = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode          = DS_SET_FILTER_FILE_CC;
-    int32             forced_FilterTableIndex = 1;
+    size_t                   forced_Size             = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID            = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode          = DS_SET_FILTER_FILE_CC;
+    int32                    forced_FilterTableIndex = 1;
+    DS_FilterFile_Payload_t *CmdPayload              = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -331,16 +335,14 @@ void DS_CmdSetFilterFile_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "FILTER FILE command: MID = 0x%%08lX, index = %%d, filter = %%d, file = %%d");
 
-    UT_CmdBuf.FilterFileCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterFileCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterFileCmd.FileTableIndex   = 4;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FileTableIndex   = 4;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
     DS_AppData.FilterTblPtr->Packet->MessageID = DS_UT_MID_1;
-    DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex]
-        .Filter[UT_CmdBuf.FilterFileCmd.FilterParmsIndex]
-        .FileTableIndex = 0;
+    DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex].Filter[CmdPayload->FilterParmsIndex].FileTableIndex = 0;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), forced_FilterTableIndex);
@@ -351,11 +353,11 @@ void DS_CmdSetFilterFile_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex]
-                          .Filter[UT_CmdBuf.FilterFileCmd.FilterParmsIndex]
-                          .FileTableIndex == UT_CmdBuf.FilterFileCmd.FileTableIndex,
-                  "DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex].Filter[UT_CmdBuf.FilterFileCmd."
-                  "FilterParmsIndex].FileTableIndex == UT_CmdBuf.FilterFileCmd.FileTableIndex");
+    UtAssert_True(
+        DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex].Filter[CmdPayload->FilterParmsIndex].FileTableIndex ==
+            CmdPayload->FileTableIndex,
+        "DS_AppData.FilterTblPtr->Packet[forced_FilterTableIndex].Filter[CmdPayload->"
+        "FilterParmsIndex].FileTableIndex == CmdPayload->FileTableIndex");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -407,9 +409,10 @@ void DS_CmdSetFilterFile_Test_InvalidCommandLength(void)
 
 void DS_CmdSetFilterFile_Test_InvalidMessageID(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    DS_FilterFile_Payload_t *CmdPayload     = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -420,7 +423,7 @@ void DS_CmdSetFilterFile_Test_InvalidMessageID(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER FILE command arg: invalid messageID = 0x%%08lX");
 
-    UT_CmdBuf.FilterFileCmd.MessageID = CFE_SB_INVALID_MSG_ID;
+    CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
     DS_CmdSetFilterFile(&UT_CmdBuf.Buf);
@@ -442,9 +445,10 @@ void DS_CmdSetFilterFile_Test_InvalidMessageID(void)
 
 void DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    DS_FilterFile_Payload_t *CmdPayload     = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -455,8 +459,8 @@ void DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER FILE command arg: filter parameters index = %%d");
 
-    UT_CmdBuf.FilterFileCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterFileCmd.FilterParmsIndex = DS_FILTERS_PER_PACKET;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
     DS_CmdSetFilterFile(&UT_CmdBuf.Buf);
@@ -478,9 +482,10 @@ void DS_CmdSetFilterFile_Test_InvalidFilterParametersIndex(void)
 
 void DS_CmdSetFilterFile_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    DS_FilterFile_Payload_t *CmdPayload     = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -491,9 +496,9 @@ void DS_CmdSetFilterFile_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER FILE command arg: file table index = %%d");
 
-    UT_CmdBuf.FilterFileCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterFileCmd.FilterParmsIndex = 1;
-    UT_CmdBuf.FilterFileCmd.FileTableIndex   = 99;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = 1;
+    CmdPayload->FileTableIndex   = 99;
 
     /* Execute the function being tested */
     DS_CmdSetFilterFile(&UT_CmdBuf.Buf);
@@ -515,9 +520,10 @@ void DS_CmdSetFilterFile_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetFilterFile_Test_FilterTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    DS_FilterFile_Payload_t *CmdPayload     = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -528,9 +534,9 @@ void DS_CmdSetFilterFile_Test_FilterTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER FILE command: packet filter table is not loaded");
 
-    UT_CmdBuf.FilterFileCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterFileCmd.FilterParmsIndex = 1;
-    UT_CmdBuf.FilterFileCmd.FileTableIndex   = 1;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = 1;
+    CmdPayload->FileTableIndex   = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -559,9 +565,10 @@ void DS_CmdSetFilterFile_Test_MessageIDNotInFilterTable(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterFileCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_FILE_CC;
+    DS_FilterFile_Payload_t *CmdPayload     = &UT_CmdBuf.FilterFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -572,9 +579,9 @@ void DS_CmdSetFilterFile_Test_MessageIDNotInFilterTable(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER FILE command: Message ID 0x%%08lX is not in filter table");
 
-    UT_CmdBuf.FilterFileCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterFileCmd.MessageID        = DS_UT_MID_2;
-    UT_CmdBuf.FilterFileCmd.FileTableIndex   = 4;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_2;
+    CmdPayload->FileTableIndex   = 4;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -605,9 +612,10 @@ void DS_CmdSetFilterType_Test_Nominal(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -618,9 +626,9 @@ void DS_CmdSetFilterType_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "FILTER TYPE command: MID = 0x%%08lX, index = %%d, filter = %%d, type = %%d");
 
-    UT_CmdBuf.FilterTypeCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterTypeCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterTypeCmd.FilterType       = 1;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterType       = 1;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -634,9 +642,8 @@ void DS_CmdSetFilterType_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(
-        DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterTypeCmd.FilterParmsIndex].FilterType == 1,
-        "DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterTypeCmd.FilterParmsIndex].FilterType == 1");
+    UtAssert_True(DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].FilterType == 1,
+                  "DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].FilterType == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -688,9 +695,10 @@ void DS_CmdSetFilterType_Test_InvalidCommandLength(void)
 
 void DS_CmdSetFilterType_Test_InvalidMessageID(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -701,7 +709,7 @@ void DS_CmdSetFilterType_Test_InvalidMessageID(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER TYPE command arg: invalid messageID = 0x%%08lX");
 
-    UT_CmdBuf.FilterTypeCmd.MessageID = CFE_SB_INVALID_MSG_ID;
+    CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
     DS_CmdSetFilterType(&UT_CmdBuf.Buf);
@@ -723,9 +731,10 @@ void DS_CmdSetFilterType_Test_InvalidMessageID(void)
 
 void DS_CmdSetFilterType_Test_InvalidFilterParametersIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -736,8 +745,8 @@ void DS_CmdSetFilterType_Test_InvalidFilterParametersIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER TYPE command arg: filter parameters index = %%d");
 
-    UT_CmdBuf.FilterTypeCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterTypeCmd.FilterParmsIndex = DS_FILTERS_PER_PACKET;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
     DS_CmdSetFilterType(&UT_CmdBuf.Buf);
@@ -758,9 +767,10 @@ void DS_CmdSetFilterType_Test_InvalidFilterParametersIndex(void)
 
 void DS_CmdSetFilterType_Test_InvalidFilterType(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -771,9 +781,9 @@ void DS_CmdSetFilterType_Test_InvalidFilterType(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER TYPE command arg: filter type = %%d");
 
-    UT_CmdBuf.FilterTypeCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterTypeCmd.FilterParmsIndex = 1;
-    UT_CmdBuf.FilterTypeCmd.FilterType       = false;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = 1;
+    CmdPayload->FilterType       = false;
 
     /* Execute the function being tested */
     DS_CmdSetFilterType(&UT_CmdBuf.Buf);
@@ -794,9 +804,10 @@ void DS_CmdSetFilterType_Test_InvalidFilterType(void)
 
 void DS_CmdSetFilterType_Test_FilterTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -807,9 +818,9 @@ void DS_CmdSetFilterType_Test_FilterTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER TYPE command: packet filter table is not loaded");
 
-    UT_CmdBuf.FilterTypeCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterTypeCmd.FilterParmsIndex = 1;
-    UT_CmdBuf.FilterTypeCmd.FilterType       = 1;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = 1;
+    CmdPayload->FilterType       = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyType), true);
 
@@ -837,9 +848,10 @@ void DS_CmdSetFilterType_Test_MessageIDNotInFilterTable(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    size_t                   forced_Size    = sizeof(DS_FilterTypeCmd_t);
+    CFE_SB_MsgId_t           forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t        forced_CmdCode = DS_SET_FILTER_TYPE_CC;
+    DS_FilterType_Payload_t *CmdPayload     = &UT_CmdBuf.FilterTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -850,9 +862,9 @@ void DS_CmdSetFilterType_Test_MessageIDNotInFilterTable(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER TYPE command: Message ID 0x%%08lX is not in filter table");
 
-    UT_CmdBuf.FilterTypeCmd.MessageID        = DS_UT_MID_2;
-    UT_CmdBuf.FilterTypeCmd.FilterParmsIndex = 1;
-    UT_CmdBuf.FilterTypeCmd.FilterType       = 1;
+    CmdPayload->MessageID        = DS_UT_MID_2;
+    CmdPayload->FilterParmsIndex = 1;
+    CmdPayload->FilterType       = 1;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -883,9 +895,10 @@ void DS_CmdSetFilterParms_Test_Nominal(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -896,11 +909,11 @@ void DS_CmdSetFilterParms_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "FILTER PARMS command: MID = 0x%%08lX, index = %%d, filter = %%d, N = %%d, X = %%d, O = %%d");
 
-    UT_CmdBuf.FilterParmsCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterParmsCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_N      = 0;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_X      = 0;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_O      = 0;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->Algorithm_N      = 0;
+    CmdPayload->Algorithm_X      = 0;
+    CmdPayload->Algorithm_O      = 0;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -914,17 +927,14 @@ void DS_CmdSetFilterParms_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(
-        DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_N == 0,
-        "DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_N == 0");
+    UtAssert_True(DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_N == 0,
+                  "DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_N == 0");
 
-    UtAssert_True(
-        DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_X == 0,
-        "DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_X == 0");
+    UtAssert_True(DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_X == 0,
+                  "DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_X == 0");
 
-    UtAssert_True(
-        DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_O == 0,
-        "DS_AppData.FilterTblPtr->Packet[0].Filter[UT_CmdBuf.FilterParmsCmd.FilterParmsIndex].Algorithm_O == 0");
+    UtAssert_True(DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_O == 0,
+                  "DS_AppData.FilterTblPtr->Packet[0].Filter[CmdPayload->FilterParmsIndex].Algorithm_O == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -976,9 +986,10 @@ void DS_CmdSetFilterParms_Test_InvalidCommandLength(void)
 
 void DS_CmdSetFilterParms_Test_InvalidMessageID(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -989,7 +1000,7 @@ void DS_CmdSetFilterParms_Test_InvalidMessageID(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER PARMS command arg: invalid messageID = 0x%%08lX");
 
-    UT_CmdBuf.FilterParmsCmd.MessageID = CFE_SB_INVALID_MSG_ID;
+    CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
     DS_CmdSetFilterParms(&UT_CmdBuf.Buf);
@@ -1011,9 +1022,10 @@ void DS_CmdSetFilterParms_Test_InvalidMessageID(void)
 
 void DS_CmdSetFilterParms_Test_InvalidFilterParametersIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1024,8 +1036,8 @@ void DS_CmdSetFilterParms_Test_InvalidFilterParametersIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER PARMS command arg: filter parameters index = %%d");
 
-    UT_CmdBuf.FilterParmsCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterParmsCmd.FilterParmsIndex = DS_FILTERS_PER_PACKET;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
     DS_CmdSetFilterParms(&UT_CmdBuf.Buf);
@@ -1049,9 +1061,10 @@ void DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1062,11 +1075,11 @@ void DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER PARMS command arg: N = %%d, X = %%d, O = %%d");
 
-    UT_CmdBuf.FilterParmsCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterParmsCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_N      = 1;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_X      = 1;
-    UT_CmdBuf.FilterParmsCmd.Algorithm_O      = 1;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->Algorithm_N      = 1;
+    CmdPayload->Algorithm_X      = 1;
+    CmdPayload->Algorithm_O      = 1;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -1092,9 +1105,10 @@ void DS_CmdSetFilterParms_Test_InvalidFilterAlgorithm(void)
 
 void DS_CmdSetFilterParms_Test_FilterTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1105,8 +1119,8 @@ void DS_CmdSetFilterParms_Test_FilterTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER PARMS command: packet filter table is not loaded");
 
-    UT_CmdBuf.FilterParmsCmd.MessageID        = DS_UT_MID_1;
-    UT_CmdBuf.FilterParmsCmd.FilterParmsIndex = 1;
+    CmdPayload->MessageID        = DS_UT_MID_1;
+    CmdPayload->FilterParmsIndex = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyParms), true);
 
@@ -1135,9 +1149,10 @@ void DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_FilterParmsCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    size_t                    forced_Size    = sizeof(DS_FilterParmsCmd_t);
+    CFE_SB_MsgId_t            forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t         forced_CmdCode = DS_SET_FILTER_PARMS_CC;
+    DS_FilterParms_Payload_t *CmdPayload     = &UT_CmdBuf.FilterParmsCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1148,8 +1163,8 @@ void DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid FILTER PARMS command: Message ID 0x%%08lX is not in filter table");
 
-    UT_CmdBuf.FilterParmsCmd.FilterParmsIndex = 2;
-    UT_CmdBuf.FilterParmsCmd.MessageID        = DS_UT_MID_2;
+    CmdPayload->FilterParmsIndex = 2;
+    CmdPayload->MessageID        = DS_UT_MID_2;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -1178,9 +1193,10 @@ void DS_CmdSetFilterParms_Test_MessageIDNotInFilterTable(void)
 
 void DS_CmdSetDestType_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestTypeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    DS_DestType_Payload_t *CmdPayload     = &UT_CmdBuf.DestTypeCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1191,8 +1207,8 @@ void DS_CmdSetDestType_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST TYPE command: file table index = %%d, filename type = %%d");
 
-    UT_CmdBuf.DestTypeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestTypeCmd.FileNameType   = 2;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->FileNameType   = 2;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyType), true);
@@ -1203,8 +1219,8 @@ void DS_CmdSetDestType_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestTypeCmd.FileTableIndex].FileNameType == 2,
-                  "DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestTypeCmd.FileTableIndex].FileNameType == 2");
+    UtAssert_True(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].FileNameType == 2,
+                  "DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].FileNameType == 2");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -1256,9 +1272,10 @@ void DS_CmdSetDestType_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestType_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestTypeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    DS_DestType_Payload_t *CmdPayload     = &UT_CmdBuf.DestTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1269,7 +1286,7 @@ void DS_CmdSetDestType_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST TYPE command arg: file table index = %%d");
 
-    UT_CmdBuf.DestTypeCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdSetDestType(&UT_CmdBuf.Buf);
@@ -1291,9 +1308,10 @@ void DS_CmdSetDestType_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestType_Test_InvalidFilenameType(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestTypeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    DS_DestType_Payload_t *CmdPayload     = &UT_CmdBuf.DestTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1304,8 +1322,8 @@ void DS_CmdSetDestType_Test_InvalidFilenameType(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST TYPE command arg: filename type = %%d");
 
-    UT_CmdBuf.DestTypeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestTypeCmd.FileNameType   = 99;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->FileNameType   = 99;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -1329,9 +1347,10 @@ void DS_CmdSetDestType_Test_InvalidFilenameType(void)
 
 void DS_CmdSetDestType_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestTypeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestTypeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_TYPE_CC;
+    DS_DestType_Payload_t *CmdPayload     = &UT_CmdBuf.DestTypeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1342,8 +1361,8 @@ void DS_CmdSetDestType_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST TYPE command: destination file table is not loaded");
 
-    UT_CmdBuf.DestTypeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestTypeCmd.FileNameType   = 2;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->FileNameType   = 2;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -1370,9 +1389,10 @@ void DS_CmdSetDestType_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestState_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
+    size_t                  forced_Size    = sizeof(DS_DestStateCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_STATE_CC;
+    DS_DestState_Payload_t *CmdPayload     = &UT_CmdBuf.DestStateCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1383,8 +1403,8 @@ void DS_CmdSetDestState_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST STATE command: file table index = %%d, file state = %%d");
 
-    UT_CmdBuf.DestStateCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestStateCmd.EnableState    = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->EnableState    = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyState), true);
@@ -1395,10 +1415,9 @@ void DS_CmdSetDestState_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestStateCmd.FileTableIndex].EnableState ==
-                      UT_CmdBuf.DestStateCmd.EnableState,
-                  "DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestStateCmd.FileTableIndex].EnableState == "
-                  "UT_CmdBuf.DestStateCmd.EnableState");
+    UtAssert_True(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].EnableState == CmdPayload->EnableState,
+                  "DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].EnableState == "
+                  "CmdPayload->EnableState");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -1450,9 +1469,10 @@ void DS_CmdSetDestState_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestState_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
+    size_t                  forced_Size    = sizeof(DS_DestStateCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_STATE_CC;
+    DS_DestState_Payload_t *CmdPayload     = &UT_CmdBuf.DestStateCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1463,7 +1483,7 @@ void DS_CmdSetDestState_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST STATE command arg: file table index = %%d");
 
-    UT_CmdBuf.DestStateCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdSetDestState(&UT_CmdBuf.Buf);
@@ -1485,9 +1505,10 @@ void DS_CmdSetDestState_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestState_Test_InvalidFileState(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
+    size_t                  forced_Size    = sizeof(DS_DestStateCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_STATE_CC;
+    DS_DestState_Payload_t *CmdPayload     = &UT_CmdBuf.DestStateCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1498,8 +1519,8 @@ void DS_CmdSetDestState_Test_InvalidFileState(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST STATE command arg: file state = %%d");
 
-    UT_CmdBuf.DestStateCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestStateCmd.EnableState    = 99;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->EnableState    = 99;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -1523,9 +1544,10 @@ void DS_CmdSetDestState_Test_InvalidFileState(void)
 
 void DS_CmdSetDestState_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestStateCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_STATE_CC;
+    size_t                  forced_Size    = sizeof(DS_DestStateCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_STATE_CC;
+    DS_DestState_Payload_t *CmdPayload     = &UT_CmdBuf.DestStateCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1536,7 +1558,7 @@ void DS_CmdSetDestState_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST STATE command: destination file table is not loaded");
 
-    UT_CmdBuf.DestStateCmd.FileTableIndex = 1;
+    CmdPayload->FileTableIndex = 1;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -1563,9 +1585,10 @@ void DS_CmdSetDestState_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestPath_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
+    size_t                 forced_Size    = sizeof(DS_DestPathCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_PATH_CC;
+    DS_DestPath_Payload_t *CmdPayload     = &UT_CmdBuf.DestPathCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1576,8 +1599,8 @@ void DS_CmdSetDestPath_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST PATH command: file table index = %%d, pathname = '%%s'");
 
-    UT_CmdBuf.DestPathCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestPathCmd.Pathname, "pathname", sizeof(UT_CmdBuf.DestPathCmd.Pathname) - 1);
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Pathname, "pathname", sizeof(CmdPayload->Pathname) - 1);
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -1587,9 +1610,9 @@ void DS_CmdSetDestPath_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestPathCmd.FileTableIndex].Pathname, "pathname",
+    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Pathname, "pathname",
                           sizeof(DS_AppData.DestFileTblPtr->File[0].Pathname)) == 0,
-                  "strncmp (DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestPathCmd.FileTableIndex].Pathname, "
+                  "strncmp (DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Pathname, "
                   "'pathname', sizeof(DestFileTable.File[0].Pathname) - 1) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1642,9 +1665,10 @@ void DS_CmdSetDestPath_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestPath_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
+    size_t                 forced_Size    = sizeof(DS_DestPathCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_PATH_CC;
+    DS_DestPath_Payload_t *CmdPayload     = &UT_CmdBuf.DestPathCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1655,7 +1679,7 @@ void DS_CmdSetDestPath_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST PATH command arg: file table index = %%d");
 
-    UT_CmdBuf.DestPathCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdSetDestPath(&UT_CmdBuf.Buf);
@@ -1677,9 +1701,10 @@ void DS_CmdSetDestPath_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestPath_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestPathCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_PATH_CC;
+    size_t                 forced_Size    = sizeof(DS_DestPathCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_PATH_CC;
+    DS_DestPath_Payload_t *CmdPayload     = &UT_CmdBuf.DestPathCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1690,8 +1715,8 @@ void DS_CmdSetDestPath_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST PATH command: destination file table is not loaded");
 
-    UT_CmdBuf.DestPathCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestPathCmd.Pathname, "pathname", sizeof(UT_CmdBuf.DestPathCmd.Pathname) - 1);
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Pathname, "pathname", sizeof(CmdPayload->Pathname) - 1);
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -1717,9 +1742,10 @@ void DS_CmdSetDestPath_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestBase_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestBaseCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_BASE_CC;
+    DS_DestBase_Payload_t *CmdPayload     = &UT_CmdBuf.DestBaseCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1730,8 +1756,8 @@ void DS_CmdSetDestBase_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST BASE command: file table index = %%d, base filename = '%%s'");
 
-    UT_CmdBuf.DestBaseCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestBaseCmd.Basename, "base", sizeof(UT_CmdBuf.DestBaseCmd.Basename) - 1);
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Basename, "base", sizeof(CmdPayload->Basename) - 1);
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -1741,9 +1767,9 @@ void DS_CmdSetDestBase_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestBaseCmd.FileTableIndex].Basename, "base",
+    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Basename, "base",
                           sizeof(DS_AppData.DestFileTblPtr->File[0].Basename)) == 0,
-                  "strncmp (DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestBaseCmd.FileTableIndex].Basename, 'base', "
+                  "strncmp (DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Basename, 'base', "
                   "sizeof(DestFileTable.File[0].Basename)) == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1796,9 +1822,10 @@ void DS_CmdSetDestBase_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestBase_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestBaseCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_BASE_CC;
+    DS_DestBase_Payload_t *CmdPayload     = &UT_CmdBuf.DestBaseCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1809,7 +1836,7 @@ void DS_CmdSetDestBase_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST BASE command arg: file table index = %%d");
 
-    UT_CmdBuf.DestBaseCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdSetDestBase(&UT_CmdBuf.Buf);
@@ -1831,9 +1858,10 @@ void DS_CmdSetDestBase_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestBase_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestBaseCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_BASE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestBaseCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_BASE_CC;
+    DS_DestBase_Payload_t *CmdPayload     = &UT_CmdBuf.DestBaseCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1844,8 +1872,8 @@ void DS_CmdSetDestBase_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST BASE command: destination file table is not loaded");
 
-    UT_CmdBuf.DestBaseCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestBaseCmd.Basename, "base", sizeof(UT_CmdBuf.DestBaseCmd.Basename));
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Basename, "base", sizeof(CmdPayload->Basename));
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -1871,9 +1899,10 @@ void DS_CmdSetDestBase_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestExt_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
+    size_t                forced_Size    = sizeof(DS_DestExtCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_EXT_CC;
+    DS_DestExt_Payload_t *CmdPayload     = &UT_CmdBuf.DestExtCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -1884,8 +1913,8 @@ void DS_CmdSetDestExt_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST EXT command: file table index = %%d, extension = '%%s'");
 
-    UT_CmdBuf.DestExtCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestExtCmd.Extension, "txt", DS_EXTENSION_BUFSIZE);
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Extension, "txt", DS_EXTENSION_BUFSIZE);
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
@@ -1895,9 +1924,9 @@ void DS_CmdSetDestExt_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestExtCmd.FileTableIndex].Extension, "txt",
+    UtAssert_True(strncmp(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Extension, "txt",
                           DS_EXTENSION_BUFSIZE) == 0,
-                  "strncmp (DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestExtCmd.FileTableIndex].Extension, 'txt', "
+                  "strncmp (DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].Extension, 'txt', "
                   "DS_EXTENSION_BUFSIZE) == "
                   "0");
 
@@ -1951,9 +1980,10 @@ void DS_CmdSetDestExt_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestExt_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
+    size_t                forced_Size    = sizeof(DS_DestExtCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_EXT_CC;
+    DS_DestExt_Payload_t *CmdPayload     = &UT_CmdBuf.DestExtCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1964,7 +1994,7 @@ void DS_CmdSetDestExt_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST EXT command arg: file table index = %%d");
 
-    UT_CmdBuf.DestExtCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdSetDestExt(&UT_CmdBuf.Buf);
@@ -1986,9 +2016,10 @@ void DS_CmdSetDestExt_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestExt_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestExtCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_EXT_CC;
+    size_t                forced_Size    = sizeof(DS_DestExtCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_EXT_CC;
+    DS_DestExt_Payload_t *CmdPayload     = &UT_CmdBuf.DestExtCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -1999,8 +2030,8 @@ void DS_CmdSetDestExt_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST EXT command: destination file table is not loaded");
 
-    UT_CmdBuf.DestExtCmd.FileTableIndex = 1;
-    strncpy(UT_CmdBuf.DestExtCmd.Extension, "txt", DS_EXTENSION_BUFSIZE);
+    CmdPayload->FileTableIndex = 1;
+    strncpy(CmdPayload->Extension, "txt", DS_EXTENSION_BUFSIZE);
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2026,9 +2057,10 @@ void DS_CmdSetDestExt_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestSize_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestSizeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    DS_DestSize_Payload_t *CmdPayload     = &UT_CmdBuf.DestSizeCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2039,8 +2071,8 @@ void DS_CmdSetDestSize_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST SIZE command: file table index = %%d, size limit = %%d");
 
-    UT_CmdBuf.DestSizeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestSizeCmd.MaxFileSize    = 100000000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileSize    = 100000000;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifySize), true);
@@ -2051,8 +2083,8 @@ void DS_CmdSetDestSize_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestSizeCmd.FileTableIndex].MaxFileSize == 100000000,
-                  "DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestSizeCmd.FileTableIndex].MaxFileSize == 100000000");
+    UtAssert_True(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].MaxFileSize == 100000000,
+                  "DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].MaxFileSize == 100000000");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -2071,9 +2103,10 @@ void DS_CmdSetDestSize_Test_Nominal(void)
 
 void DS_CmdSetDestSize_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestSizeCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestSizeCmd_t) + 1;
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    DS_DestSize_Payload_t *CmdPayload     = &UT_CmdBuf.DestSizeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2084,8 +2117,8 @@ void DS_CmdSetDestSize_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST SIZE command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.DestSizeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestSizeCmd.MaxFileSize    = 100000000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileSize    = 100000000;
 
     /* Execute the function being tested */
     DS_CmdSetDestSize(&UT_CmdBuf.Buf);
@@ -2107,9 +2140,10 @@ void DS_CmdSetDestSize_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestSize_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestSizeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    DS_DestSize_Payload_t *CmdPayload     = &UT_CmdBuf.DestSizeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2120,8 +2154,8 @@ void DS_CmdSetDestSize_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST SIZE command arg: file table index = %%d");
 
-    UT_CmdBuf.DestSizeCmd.FileTableIndex = 99;
-    UT_CmdBuf.DestSizeCmd.MaxFileSize    = 100000000;
+    CmdPayload->FileTableIndex = 99;
+    CmdPayload->MaxFileSize    = 100000000;
 
     /* Execute the function being tested */
     DS_CmdSetDestSize(&UT_CmdBuf.Buf);
@@ -2143,9 +2177,10 @@ void DS_CmdSetDestSize_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestSize_Test_InvalidFileSizeLimit(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestSizeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    DS_DestSize_Payload_t *CmdPayload     = &UT_CmdBuf.DestSizeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2156,8 +2191,8 @@ void DS_CmdSetDestSize_Test_InvalidFileSizeLimit(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST SIZE command arg: size limit = %%d");
 
-    UT_CmdBuf.DestSizeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestSizeCmd.MaxFileSize    = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileSize    = 1;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2183,9 +2218,10 @@ void DS_CmdSetDestSize_Test_InvalidFileSizeLimit(void)
 
 void DS_CmdSetDestSize_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestSizeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    size_t                 forced_Size    = sizeof(DS_DestSizeCmd_t);
+    CFE_SB_MsgId_t         forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t      forced_CmdCode = DS_SET_DEST_SIZE_CC;
+    DS_DestSize_Payload_t *CmdPayload     = &UT_CmdBuf.DestSizeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2196,8 +2232,8 @@ void DS_CmdSetDestSize_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST SIZE command: destination file table is not loaded");
 
-    UT_CmdBuf.DestSizeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestSizeCmd.MaxFileSize    = 100000000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileSize    = 100000000;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2224,9 +2260,10 @@ void DS_CmdSetDestSize_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestAge_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
+    size_t                forced_Size    = sizeof(DS_DestAgeCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_AGE_CC;
+    DS_DestAge_Payload_t *CmdPayload     = &UT_CmdBuf.DestAgeCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2237,8 +2274,8 @@ void DS_CmdSetDestAge_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST AGE command: file table index = %%d, age limit = %%d");
 
-    UT_CmdBuf.DestAgeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestAgeCmd.MaxFileAge     = 1000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileAge     = 1000;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyAge), true);
@@ -2249,8 +2286,8 @@ void DS_CmdSetDestAge_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestAgeCmd.FileTableIndex].MaxFileAge == 1000,
-                  "DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestAgeCmd.FileTableIndex].MaxFileAge == 1000");
+    UtAssert_True(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].MaxFileAge == 1000,
+                  "DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].MaxFileAge == 1000");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -2269,9 +2306,10 @@ void DS_CmdSetDestAge_Test_Nominal(void)
 
 void DS_CmdSetDestAge_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestAgeCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
+    size_t                forced_Size    = sizeof(DS_DestAgeCmd_t) + 1;
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_AGE_CC;
+    DS_DestAge_Payload_t *CmdPayload     = &UT_CmdBuf.DestAgeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2282,8 +2320,8 @@ void DS_CmdSetDestAge_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST AGE command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.DestAgeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestAgeCmd.MaxFileAge     = 1000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileAge     = 1000;
 
     /* Execute the function being tested */
     DS_CmdSetDestAge(&UT_CmdBuf.Buf);
@@ -2305,9 +2343,10 @@ void DS_CmdSetDestAge_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestAge_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
+    size_t                forced_Size    = sizeof(DS_DestAgeCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_AGE_CC;
+    DS_DestAge_Payload_t *CmdPayload     = &UT_CmdBuf.DestAgeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2318,8 +2357,8 @@ void DS_CmdSetDestAge_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST AGE command arg: file table index = %%d");
 
-    UT_CmdBuf.DestAgeCmd.FileTableIndex = 99;
-    UT_CmdBuf.DestAgeCmd.MaxFileAge     = 1000;
+    CmdPayload->FileTableIndex = 99;
+    CmdPayload->MaxFileAge     = 1000;
 
     /* Execute the function being tested */
     DS_CmdSetDestAge(&UT_CmdBuf.Buf);
@@ -2341,9 +2380,10 @@ void DS_CmdSetDestAge_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestAge_Test_InvalidFileAgeLimit(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
+    size_t                forced_Size    = sizeof(DS_DestAgeCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_AGE_CC;
+    DS_DestAge_Payload_t *CmdPayload     = &UT_CmdBuf.DestAgeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2353,8 +2393,8 @@ void DS_CmdSetDestAge_Test_InvalidFileAgeLimit(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Invalid DEST AGE command arg: age limit = %%d");
 
-    UT_CmdBuf.DestAgeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestAgeCmd.MaxFileAge     = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileAge     = 1;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2380,9 +2420,10 @@ void DS_CmdSetDestAge_Test_InvalidFileAgeLimit(void)
 
 void DS_CmdSetDestAge_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestAgeCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_AGE_CC;
+    size_t                forced_Size    = sizeof(DS_DestAgeCmd_t);
+    CFE_SB_MsgId_t        forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t     forced_CmdCode = DS_SET_DEST_AGE_CC;
+    DS_DestAge_Payload_t *CmdPayload     = &UT_CmdBuf.DestAgeCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2393,8 +2434,8 @@ void DS_CmdSetDestAge_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST AGE command: destination file table is not loaded");
 
-    UT_CmdBuf.DestAgeCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestAgeCmd.MaxFileAge     = 1000;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->MaxFileAge     = 1000;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2421,9 +2462,10 @@ void DS_CmdSetDestAge_Test_FileTableNotLoaded(void)
 
 void DS_CmdSetDestCount_Test_Nominal(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    size_t                  forced_Size    = sizeof(DS_DestCountCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    DS_DestCount_Payload_t *CmdPayload     = &UT_CmdBuf.DestCountCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -2434,8 +2476,8 @@ void DS_CmdSetDestCount_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "DEST COUNT command: file table index = %%d, sequence count = %%d");
 
-    UT_CmdBuf.DestCountCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestCountCmd.SequenceCount  = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->SequenceCount  = 1;
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyCount), true);
@@ -2446,11 +2488,11 @@ void DS_CmdSetDestCount_Test_Nominal(void)
     /* Verify results */
     UtAssert_True(DS_AppData.CmdAcceptedCounter == 1, "DS_AppData.CmdAcceptedCounter == 1");
 
-    UtAssert_True(DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestCountCmd.FileTableIndex].SequenceCount == 1,
-                  "DS_AppData.DestFileTblPtr->File[UT_CmdBuf.DestCountCmd.FileTableIndex].SequenceCount == 1");
+    UtAssert_True(DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].SequenceCount == 1,
+                  "DS_AppData.DestFileTblPtr->File[CmdPayload->FileTableIndex].SequenceCount == 1");
 
-    UtAssert_True(DS_AppData.FileStatus[UT_CmdBuf.DestCountCmd.FileTableIndex].FileCount == 1,
-                  "DS_AppData.FileStatus[UT_CmdBuf.DestCountCmd.FileTableIndex].FileCount == 1");
+    UtAssert_True(DS_AppData.FileStatus[CmdPayload->FileTableIndex].FileCount == 1,
+                  "DS_AppData.FileStatus[CmdPayload->FileTableIndex].FileCount == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
@@ -2469,9 +2511,10 @@ void DS_CmdSetDestCount_Test_Nominal(void)
 
 void DS_CmdSetDestCount_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestCountCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    size_t                  forced_Size    = sizeof(DS_DestCountCmd_t) + 1;
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    DS_DestCount_Payload_t *CmdPayload     = &UT_CmdBuf.DestCountCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2482,8 +2525,8 @@ void DS_CmdSetDestCount_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST COUNT command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.DestCountCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestCountCmd.SequenceCount  = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->SequenceCount  = 1;
 
     /* Execute the function being tested */
     DS_CmdSetDestCount(&UT_CmdBuf.Buf);
@@ -2505,9 +2548,10 @@ void DS_CmdSetDestCount_Test_InvalidCommandLength(void)
 
 void DS_CmdSetDestCount_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    size_t                  forced_Size    = sizeof(DS_DestCountCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    DS_DestCount_Payload_t *CmdPayload     = &UT_CmdBuf.DestCountCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2518,8 +2562,8 @@ void DS_CmdSetDestCount_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST COUNT command arg: file table index = %%d");
 
-    UT_CmdBuf.DestCountCmd.FileTableIndex = 99;
-    UT_CmdBuf.DestCountCmd.SequenceCount  = 1;
+    CmdPayload->FileTableIndex = 99;
+    CmdPayload->SequenceCount  = 1;
 
     /* Execute the function being tested */
     DS_CmdSetDestCount(&UT_CmdBuf.Buf);
@@ -2541,9 +2585,10 @@ void DS_CmdSetDestCount_Test_InvalidFileTableIndex(void)
 
 void DS_CmdSetDestCount_Test_InvalidFileSequenceCount(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    size_t                  forced_Size    = sizeof(DS_DestCountCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    DS_DestCount_Payload_t *CmdPayload     = &UT_CmdBuf.DestCountCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2554,8 +2599,8 @@ void DS_CmdSetDestCount_Test_InvalidFileSequenceCount(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST COUNT command arg: sequence count = %%d");
 
-    UT_CmdBuf.DestCountCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestCountCmd.SequenceCount  = -1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->SequenceCount  = -1;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2581,9 +2626,10 @@ void DS_CmdSetDestCount_Test_InvalidFileSequenceCount(void)
 
 void DS_CmdSetDestCount_Test_FileTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_DestCountCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    size_t                  forced_Size    = sizeof(DS_DestCountCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_SET_DEST_COUNT_CC;
+    DS_DestCount_Payload_t *CmdPayload     = &UT_CmdBuf.DestCountCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2594,8 +2640,8 @@ void DS_CmdSetDestCount_Test_FileTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST COUNT command: destination file table is not loaded");
 
-    UT_CmdBuf.DestCountCmd.FileTableIndex = 1;
-    UT_CmdBuf.DestCountCmd.SequenceCount  = 1;
+    CmdPayload->FileTableIndex = 1;
+    CmdPayload->SequenceCount  = 1;
 
     DS_AppData.DestFileTblPtr = 0;
 
@@ -2626,9 +2672,10 @@ void DS_CmdCloseFile_Test_Nominal(void)
     uint8  call_count_DS_FileUpdateHeader = 0;
     uint8  call_count_DS_FileCloseDest    = 0;
 
-    size_t            forced_Size    = sizeof(DS_CloseFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
+    size_t                  forced_Size    = sizeof(DS_CloseFileCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_CLOSE_FILE_CC;
+    DS_CloseFile_Payload_t *CmdPayload     = &UT_CmdBuf.CloseFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2640,9 +2687,9 @@ void DS_CmdCloseFile_Test_Nominal(void)
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
-    UT_CmdBuf.CloseFileCmd.FileTableIndex = 0;
+    CmdPayload->FileTableIndex = 0;
 
-    DS_AppData.FileStatus[UT_CmdBuf.CloseFileCmd.FileTableIndex].FileHandle = DS_UT_OBJID_1;
+    DS_AppData.FileStatus[CmdPayload->FileTableIndex].FileHandle = DS_UT_OBJID_1;
 
     for (i = 1; i < DS_DEST_FILE_CNT; i++)
     {
@@ -2684,9 +2731,10 @@ void DS_CmdCloseFile_Test_NominalAlreadyClosed(void)
     uint8  call_count_DS_FileUpdateHeader = 0;
     uint8  call_count_DS_FileCloseDest    = 0;
 
-    size_t            forced_Size    = sizeof(DS_CloseFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
+    size_t                  forced_Size    = sizeof(DS_CloseFileCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_CLOSE_FILE_CC;
+    DS_CloseFile_Payload_t *CmdPayload     = &UT_CmdBuf.CloseFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2698,7 +2746,7 @@ void DS_CmdCloseFile_Test_NominalAlreadyClosed(void)
 
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
-    UT_CmdBuf.CloseFileCmd.FileTableIndex = 0;
+    CmdPayload->FileTableIndex = 0;
 
     for (i = 0; i < DS_DEST_FILE_CNT; i++)
     {
@@ -2736,9 +2784,10 @@ void DS_CmdCloseFile_Test_NominalAlreadyClosed(void)
 
 void DS_CmdCloseFile_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_CloseFileCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
+    size_t                  forced_Size    = sizeof(DS_CloseFileCmd_t) + 1;
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_CLOSE_FILE_CC;
+    DS_CloseFile_Payload_t *CmdPayload     = &UT_CmdBuf.CloseFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2749,7 +2798,7 @@ void DS_CmdCloseFile_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST CLOSE command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.CloseFileCmd.FileTableIndex = 0;
+    CmdPayload->FileTableIndex = 0;
 
     /* Execute the function being tested */
     DS_CmdCloseFile(&UT_CmdBuf.Buf);
@@ -2771,9 +2820,10 @@ void DS_CmdCloseFile_Test_InvalidCommandLength(void)
 
 void DS_CmdCloseFile_Test_InvalidFileTableIndex(void)
 {
-    size_t            forced_Size    = sizeof(DS_CloseFileCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_CLOSE_FILE_CC;
+    size_t                  forced_Size    = sizeof(DS_CloseFileCmd_t);
+    CFE_SB_MsgId_t          forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t       forced_CmdCode = DS_CLOSE_FILE_CC;
+    DS_CloseFile_Payload_t *CmdPayload     = &UT_CmdBuf.CloseFileCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -2786,7 +2836,7 @@ void DS_CmdCloseFile_Test_InvalidFileTableIndex(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid DEST CLOSE command arg: file table index = %%d");
 
-    UT_CmdBuf.CloseFileCmd.FileTableIndex = 99;
+    CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
     DS_CmdCloseFile(&UT_CmdBuf.Buf);
@@ -3046,9 +3096,10 @@ void DS_CmdAddMID_Test_Nominal(void)
     int32         FilterTableIndex;
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -3062,7 +3113,7 @@ void DS_CmdAddMID_Test_Nominal(void)
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_AddMidCmd_t), "DS_AddMidCmd_t is 32-bit aligned");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     DS_AppData.HashTable[0]                                   = &HashLink;
     HashLink.Index                                            = 0;
@@ -3153,9 +3204,10 @@ void DS_CmdAddMID_Test_Nominal(void)
 
 void DS_CmdAddMID_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t) + 1;
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3166,7 +3218,7 @@ void DS_CmdAddMID_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid ADD MID command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* Execute the function being tested */
     DS_CmdAddMID(&UT_CmdBuf.Buf);
@@ -3188,9 +3240,10 @@ void DS_CmdAddMID_Test_InvalidCommandLength(void)
 
 void DS_CmdAddMID_Test_InvalidMessageID(void)
 {
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3201,7 +3254,7 @@ void DS_CmdAddMID_Test_InvalidMessageID(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid ADD MID command arg: invalid MID = 0x%%08lX");
 
-    UT_CmdBuf.AddMidCmd.MessageID = CFE_SB_INVALID_MSG_ID;
+    CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
     DS_CmdAddMID(&UT_CmdBuf.Buf);
@@ -3227,9 +3280,10 @@ void DS_CmdAddMID_Test_InvalidMessageID(void)
 
 void DS_CmdAddMID_Test_FilterTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3240,7 +3294,7 @@ void DS_CmdAddMID_Test_FilterTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid ADD MID command: filter table is not loaded");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* Reset table pointer to NULL (set in test setup) */
     DS_AppData.FilterTblPtr = NULL;
@@ -3267,9 +3321,10 @@ void DS_CmdAddMID_Test_MIDAlreadyInFilterTable(void)
 {
     DS_HashLink_t HashLink;
 
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3280,7 +3335,7 @@ void DS_CmdAddMID_Test_MIDAlreadyInFilterTable(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid ADD MID command: MID = 0x%%08lX is already in filter table at index = %%d");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     DS_AppData.HashTable[187]                  = &HashLink;
     HashLink.Index                             = 0;
@@ -3308,9 +3363,10 @@ void DS_CmdAddMID_Test_MIDAlreadyInFilterTable(void)
 
 void DS_CmdAddMID_Test_FilterTableFull(void)
 {
-    size_t            forced_Size    = sizeof(DS_AddMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_ADD_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_AddMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_ADD_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.AddMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3320,7 +3376,7 @@ void DS_CmdAddMID_Test_FilterTableFull(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Invalid ADD MID command: filter table is full");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* both calls to DS_TableFindMsgID must return DS_INDEX_NONE */
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
@@ -3345,14 +3401,15 @@ void DS_CmdAddMID_Test_FilterTableFull(void)
 
 void DS_CmdRemoveMID_Test_Nominal(void)
 {
-    DS_HashLink_t     HashLink;
-    size_t            forced_Size      = sizeof(DS_RemoveMidCmd_t);
-    CFE_SB_MsgId_t    MessageID        = DS_UT_MID_1;
-    CFE_SB_MsgId_t    forced_MsgID     = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode   = DS_REMOVE_MID_CC;
-    int32             FilterTableIndex = 0;
-    int32             HashTableIndex   = 1;
-    int32             strCmpResult;
+    DS_HashLink_t              HashLink;
+    size_t                     forced_Size      = sizeof(DS_RemoveMidCmd_t);
+    CFE_SB_MsgId_t             MessageID        = DS_UT_MID_1;
+    CFE_SB_MsgId_t             forced_MsgID     = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode   = DS_REMOVE_MID_CC;
+    int32                      FilterTableIndex = 0;
+    int32                      HashTableIndex   = 1;
+    int32                      strCmpResult;
+    DS_AddRemoveMid_Payload_t *CmdPayload = &UT_CmdBuf.RemoveMidCmd.Payload;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
@@ -3364,7 +3421,7 @@ void DS_CmdRemoveMID_Test_Nominal(void)
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_RemoveMidCmd_t), "DS_RemoveMidCmd_t is 32-bit aligned");
 
-    UT_CmdBuf.RemoveMidCmd.MessageID                          = MessageID;
+    CmdPayload->MessageID                                     = MessageID;
     HashLink.Index                                            = FilterTableIndex;
     HashLink.MessageID                                        = MessageID;
     DS_AppData.HashTable[HashTableIndex]                      = &HashLink;
@@ -3442,9 +3499,10 @@ void DS_CmdRemoveMID_Test_Nominal(void)
 
 void DS_CmdRemoveMID_Test_InvalidCommandLength(void)
 {
-    size_t            forced_Size    = sizeof(DS_RemoveMidCmd_t) + 1;
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_REMOVE_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_RemoveMidCmd_t) + 1;
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_REMOVE_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.RemoveMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3455,7 +3513,7 @@ void DS_CmdRemoveMID_Test_InvalidCommandLength(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid REMOVE MID command length: expected = %%d, actual = %%d");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(DS_CmdRemoveMID(&UT_CmdBuf.Buf));
@@ -3477,9 +3535,10 @@ void DS_CmdRemoveMID_Test_InvalidCommandLength(void)
 
 void DS_CmdRemoveMID_Test_InvalidMessageID(void)
 {
-    size_t            forced_Size    = sizeof(DS_RemoveMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_REMOVE_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_RemoveMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_REMOVE_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.RemoveMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3490,7 +3549,7 @@ void DS_CmdRemoveMID_Test_InvalidMessageID(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid REMOVE MID command arg: invalid MID = 0x%%08lX");
 
-    UT_CmdBuf.AddMidCmd.MessageID = CFE_SB_INVALID_MSG_ID;
+    CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(DS_CmdRemoveMID(&UT_CmdBuf.Buf));
@@ -3512,9 +3571,10 @@ void DS_CmdRemoveMID_Test_InvalidMessageID(void)
 
 void DS_CmdRemoveMID_Test_FilterTableNotLoaded(void)
 {
-    size_t            forced_Size    = sizeof(DS_RemoveMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_REMOVE_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_RemoveMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_REMOVE_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.RemoveMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3525,7 +3585,7 @@ void DS_CmdRemoveMID_Test_FilterTableNotLoaded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid REMOVE MID command: filter table is not loaded");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* Reset table pointer to NULL (set in test setup) */
     DS_AppData.FilterTblPtr = NULL;
@@ -3550,9 +3610,10 @@ void DS_CmdRemoveMID_Test_FilterTableNotLoaded(void)
 
 void DS_CmdRemoveMID_Test_MessageIDNotAdded(void)
 {
-    size_t            forced_Size    = sizeof(DS_RemoveMidCmd_t);
-    CFE_SB_MsgId_t    forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
-    CFE_MSG_FcnCode_t forced_CmdCode = DS_REMOVE_MID_CC;
+    size_t                     forced_Size    = sizeof(DS_RemoveMidCmd_t);
+    CFE_SB_MsgId_t             forced_MsgID   = CFE_SB_ValueToMsgId(DS_CMD_MID);
+    CFE_MSG_FcnCode_t          forced_CmdCode = DS_REMOVE_MID_CC;
+    DS_AddRemoveMid_Payload_t *CmdPayload     = &UT_CmdBuf.RemoveMidCmd.Payload;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &forced_MsgID, sizeof(forced_MsgID), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
@@ -3564,7 +3625,7 @@ void DS_CmdRemoveMID_Test_MessageIDNotAdded(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Invalid REMOVE MID command: MID = 0x%%08lX is not in filter table");
 
-    UT_CmdBuf.AddMidCmd.MessageID = DS_UT_MID_1;
+    CmdPayload->MessageID = DS_UT_MID_1;
 
     /* Execute the function being tested */
     UtAssert_VOIDCALL(DS_CmdRemoveMID(&UT_CmdBuf.Buf));


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Puts the CMD/TLM content in a member struct called "Payload".  This makes it consistent with other CFE modules and provides a predictably named member for determining the position of non-header content.

Fixes #92

**Testing performed**
Build and run all tests, sanity check operation

**Expected behavior changes**
None, however the addition of the sub-structure may affect some compiler-added padding between members (platform dependent).

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
