### PR TITLE
Fix #104, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,14 +3,14 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with:
-      component-path: apps/ds 
+      component-path: apps/ds
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/ds'
       setup: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_ds.dox
+++ b/docs/dox_src/cfs_ds.dox
@@ -55,7 +55,7 @@
 
   This document provides a complete specification for the commands and telemetry associated
   with the CFS Data Storage (DS) application software.  The document is intended primarily
-  for users of the software (operations personal, test engineers, and maintenance personnel).
+  for users of the software (operations personnel, test engineers, and maintenance personnel).
   The last section of the document, the deployment guide section, is intended for mission
   developers when deploying and configuring the application software for a mission
   flight software build environment.

--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -173,10 +173,10 @@ void DS_AppMain(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 DS_AppInitialize(void)
+CFE_Status_t DS_AppInitialize(void)
 {
-    int32 Result;
-    int32 i = 0;
+    CFE_Status_t Result;
+    int32        i = 0;
 
     /*
     ** Initialize global data structure...
@@ -279,7 +279,7 @@ void DS_AppSendHkCmd(void)
 {
     DS_HkPacket_t  HkPacket;
     int32          i                                              = 0;
-    int32          Status                                         = 0;
+    CFE_Status_t   Status                                         = 0;
     char           FilterTblName[CFE_MISSION_TBL_MAX_NAME_LENGTH] = {0};
     CFE_TBL_Info_t FilterTblInfo;
 

--- a/fsw/src/ds_app.h
+++ b/fsw/src/ds_app.h
@@ -145,7 +145,7 @@ void DS_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 DS_AppInitialize(void);
+CFE_Status_t DS_AppInitialize(void);
 
 /**
  *  \brief Application housekeeping request command handler

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -44,13 +44,13 @@
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 DS_TableInit(void)
+CFE_Status_t DS_TableInit(void)
 {
-    int32  Result1;
-    int32  Result2;
-    bool   NeedToLoadDestTable   = false;
-    bool   NeedToLoadFilterTable = false;
-    uint16 TableRegisterFlags    = CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP;
+    CFE_Status_t Result1;
+    CFE_Status_t Result2;
+    bool         NeedToLoadDestTable   = false;
+    bool         NeedToLoadFilterTable = false;
+    uint16       TableRegisterFlags    = CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP;
 
 #if (DS_MAKE_TABLES_CRITICAL == 1)
     TableRegisterFlags |= CFE_TBL_OPT_CRITICAL;
@@ -184,8 +184,8 @@ int32 DS_TableInit(void)
 
 void DS_TableManageDestFile(void)
 {
-    int32 i = 0;
-    int32 Result;
+    int32        i = 0;
+    CFE_Status_t Result;
 
     /*
     ** Pointer will be NULL until first successful table load...
@@ -292,7 +292,7 @@ void DS_TableManageDestFile(void)
 
 void DS_TableManageFilter(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
     ** Pointer will be NULL until first successful filter table load...
@@ -394,10 +394,10 @@ void DS_TableManageFilter(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 DS_TableVerifyDestFile(const void *TableData)
+CFE_Status_t DS_TableVerifyDestFile(const void *TableData)
 {
     DS_DestFileTable_t *DestFileTable = (DS_DestFileTable_t *)TableData;
-    int32               Result        = CFE_SUCCESS;
+    CFE_Status_t        Result        = CFE_SUCCESS;
     int32               i             = 0;
 
     int32 CountGood   = 0;
@@ -510,10 +510,10 @@ bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableI
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 DS_TableVerifyFilter(const void *TableData)
+CFE_Status_t DS_TableVerifyFilter(const void *TableData)
 {
     DS_FilterTable_t *FilterTable = (DS_FilterTable_t *)TableData;
-    int32             Result      = CFE_SUCCESS;
+    CFE_Status_t      Result      = CFE_SUCCESS;
     int32             i           = 0;
 
     int32 CountGood   = 0;
@@ -869,12 +869,12 @@ void DS_TableUnsubscribe(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 DS_TableCreateCDS(void)
+CFE_Status_t DS_TableCreateCDS(void)
 {
     /* Store file sequence counts and task ena/dis state in CDS */
-    uint32 DataStoreBuffer[DS_DEST_FILE_CNT + 1] = {0};
-    int32  Result;
-    int32  i = 0;
+    uint32       DataStoreBuffer[DS_DEST_FILE_CNT + 1] = {0};
+    CFE_Status_t Result;
+    int32        i = 0;
 
     /*
     ** Request for CDS area from cFE Executive Services...
@@ -943,9 +943,9 @@ int32 DS_TableCreateCDS(void)
 void DS_TableUpdateCDS(void)
 {
     /* Store file sequence counts and task ena/dis state in CDS */
-    uint32 DataStoreBuffer[DS_DEST_FILE_CNT + 1] = {0};
-    int32  Result;
-    int32  i = 0;
+    uint32       DataStoreBuffer[DS_DEST_FILE_CNT + 1] = {0};
+    CFE_Status_t Result;
+    int32        i = 0;
 
     /*
     ** Handle is non-zero when CDS is active...

--- a/fsw/src/ds_table.h
+++ b/fsw/src/ds_table.h
@@ -72,7 +72,7 @@ typedef struct DS_HashTag
  *
  *  \sa #DS_PacketEntry_t, #DS_FilterParms_t, #DS_DestFileEntry_t
  */
-int32 DS_TableInit(void);
+CFE_Status_t DS_TableInit(void);
 
 /**
  *  \brief Manage destination file table loads, dumps, etc.
@@ -139,7 +139,7 @@ void DS_TableManageFilter(void);
  *
  *  \sa #DS_DestFileEntry_t, #DS_TableVerifyDestFileEntry
  */
-int32 DS_TableVerifyDestFile(const void *TableData);
+CFE_Status_t DS_TableVerifyDestFile(const void *TableData);
 
 /**
  *  \brief Verify destination file table entry
@@ -185,7 +185,7 @@ bool DS_TableVerifyDestFileEntry(DS_DestFileEntry_t *DestFileEntry, uint8 TableI
  *
  *  \sa #DS_PacketEntry_t, #DS_FilterParms_t, #DS_TableVerifyFilterEntry
  */
-int32 DS_TableVerifyFilter(const void *TableData);
+CFE_Status_t DS_TableVerifyFilter(const void *TableData);
 
 /**
  *  \brief Verify packet filter table entry
@@ -452,7 +452,7 @@ void DS_TableUnsubscribe(void);
  *
  *  \sa #DS_DestFileEntry_t
  */
-int32 DS_TableCreateCDS(void);
+CFE_Status_t DS_TableCreateCDS(void);
 
 /**
  *  \brief Update CDS with current filename sequence count values

--- a/unit-test/stubs/ds_app_stubs.c
+++ b/unit-test/stubs/ds_app_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for DS_AppInitialize()
  * ----------------------------------------------------
  */
-int32 DS_AppInitialize(void)
+CFE_Status_t DS_AppInitialize(void)
 {
-    UT_GenStub_SetupReturnBuffer(DS_AppInitialize, int32);
+    UT_GenStub_SetupReturnBuffer(DS_AppInitialize, CFE_Status_t);
 
     UT_GenStub_Execute(DS_AppInitialize, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(DS_AppInitialize, int32);
+    return UT_GenStub_GetReturnValue(DS_AppInitialize, CFE_Status_t);
 }
 
 /*

--- a/unit-test/stubs/ds_table_stubs.c
+++ b/unit-test/stubs/ds_table_stubs.c
@@ -48,13 +48,13 @@ int32 DS_TableAddMsgID(CFE_SB_MsgId_t MessageID, int32 FilterIndex)
  * Generated stub function for DS_TableCreateCDS()
  * ----------------------------------------------------
  */
-int32 DS_TableCreateCDS(void)
+CFE_Status_t DS_TableCreateCDS(void)
 {
-    UT_GenStub_SetupReturnBuffer(DS_TableCreateCDS, int32);
+    UT_GenStub_SetupReturnBuffer(DS_TableCreateCDS, CFE_Status_t);
 
     UT_GenStub_Execute(DS_TableCreateCDS, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(DS_TableCreateCDS, int32);
+    return UT_GenStub_GetReturnValue(DS_TableCreateCDS, CFE_Status_t);
 }
 
 /*
@@ -122,13 +122,13 @@ uint32 DS_TableHashFunction(CFE_SB_MsgId_t MessageID)
  * Generated stub function for DS_TableInit()
  * ----------------------------------------------------
  */
-int32 DS_TableInit(void)
+CFE_Status_t DS_TableInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(DS_TableInit, int32);
+    UT_GenStub_SetupReturnBuffer(DS_TableInit, CFE_Status_t);
 
     UT_GenStub_Execute(DS_TableInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(DS_TableInit, int32);
+    return UT_GenStub_GetReturnValue(DS_TableInit, CFE_Status_t);
 }
 
 /*
@@ -223,15 +223,15 @@ bool DS_TableVerifyCount(uint32 SequenceCount)
  * Generated stub function for DS_TableVerifyDestFile()
  * ----------------------------------------------------
  */
-int32 DS_TableVerifyDestFile(const void *TableData)
+CFE_Status_t DS_TableVerifyDestFile(const void *TableData)
 {
-    UT_GenStub_SetupReturnBuffer(DS_TableVerifyDestFile, int32);
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyDestFile, CFE_Status_t);
 
     UT_GenStub_AddParam(DS_TableVerifyDestFile, const void *, TableData);
 
     UT_GenStub_Execute(DS_TableVerifyDestFile, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(DS_TableVerifyDestFile, int32);
+    return UT_GenStub_GetReturnValue(DS_TableVerifyDestFile, CFE_Status_t);
 }
 
 /*
@@ -273,15 +273,15 @@ bool DS_TableVerifyFileIndex(uint16 FileTableIndex)
  * Generated stub function for DS_TableVerifyFilter()
  * ----------------------------------------------------
  */
-int32 DS_TableVerifyFilter(const void *TableData)
+CFE_Status_t DS_TableVerifyFilter(const void *TableData)
 {
-    UT_GenStub_SetupReturnBuffer(DS_TableVerifyFilter, int32);
+    UT_GenStub_SetupReturnBuffer(DS_TableVerifyFilter, CFE_Status_t);
 
     UT_GenStub_AddParam(DS_TableVerifyFilter, const void *, TableData);
 
     UT_GenStub_Execute(DS_TableVerifyFilter, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(DS_TableVerifyFilter, int32);
+    return UT_GenStub_GetReturnValue(DS_TableVerifyFilter, CFE_Status_t);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #104
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt