### PR TITLE
Fix #94, Use sizeof destination instead of source

### DIFF
--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -883,7 +883,7 @@ void DS_FileCloseDest(int32 FileIndex)
         }
 
         /* Update the path name for reporting */
-        strncpy(FileStatus->FileName, PathName, sizeof(PathName));
+        strncpy(FileStatus->FileName, PathName, sizeof(FileStatus->FileName));
     }
 #else
     /*


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #94 

**Testing performed**
Pipeline verification

**Expected behavior changes**
Successful compilation when compiling with -Werror=sizeof-pointer-memaccess

**System(s) tested on**
Pipeline

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F Martinez Pedraza - NASA GSFC 582
