### PR TITLE
Fix #107, Convert command success events to `INFORMATION` type

### DIFF
--- a/fsw/inc/ds_events.h
+++ b/fsw/inc/ds_events.h
@@ -309,7 +309,7 @@
 /**
  *  \brief DS Application Enable/Disable State Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *

--- a/fsw/inc/ds_msgdefs.h
+++ b/fsw/inc/ds_msgdefs.h
@@ -98,7 +98,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_ENADIS_CMD_EID debug event message will be sent
+ *       - The #DS_ENADIS_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -127,7 +127,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_FILE_CMD_EID debug event message will be sent
+ *       - The #DS_FILE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -160,7 +160,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_FTYPE_CMD_EID debug event message will be sent
+ *       - The #DS_FTYPE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -193,7 +193,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_PARMS_CMD_EID debug event message will be sent
+ *       - The #DS_PARMS_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -226,7 +226,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_NTYPE_CMD_EID debug event message will be sent
+ *       - The #DS_NTYPE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -257,7 +257,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_STATE_CMD_EID debug event message will be sent
+ *       - The #DS_STATE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -288,7 +288,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_PATH_CMD_EID debug event message will be sent
+ *       - The #DS_PATH_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -319,7 +319,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_BASE_CMD_EID debug event message will be sent
+ *       - The #DS_BASE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -350,7 +350,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_EXT_CMD_EID debug event message will be sent
+ *       - The #DS_EXT_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -381,7 +381,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_SIZE_CMD_EID debug event message will be sent
+ *       - The #DS_SIZE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -412,7 +412,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_AGE_CMD_EID debug event message will be sent
+ *       - The #DS_AGE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -443,7 +443,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_SEQ_CMD_EID debug event message will be sent
+ *       - The #DS_SEQ_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -473,7 +473,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_CLOSE_CMD_EID debug event message will be sent
+ *       - The #DS_CLOSE_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -530,7 +530,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_ADD_MID_CMD_EID debug event message will be sent
+ *       - The #DS_ADD_MID_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -563,7 +563,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_CLOSE_ALL_CMD_EID debug event message will be sent
+ *       - The #DS_CLOSE_ALL_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:
@@ -592,7 +592,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will increment
- *       - The #DS_REMOVE_MID_CMD_EID debug event message will be sent
+ *       - The #DS_REMOVE_MID_CMD_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -142,7 +142,7 @@ void DS_SetAppStateCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_ENADIS_CMD_EID, CFE_EVS_EventType_DEBUG, "APP STATE command: state = %d",
+        CFE_EVS_SendEvent(DS_ENADIS_CMD_EID, CFE_EVS_EventType_INFORMATION, "APP STATE command: state = %d",
                           DS_AppStateCmd->EnableState);
     }
 }
@@ -240,7 +240,7 @@ void DS_SetFilterFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
             DS_AppData.CmdAcceptedCounter++;
 
-            CFE_EVS_SendEvent(DS_FILE_CMD_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(DS_FILE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                               "FILTER FILE command: MID = 0x%08lX, index = %d, filter = %d, file = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(DS_FilterFileCmd->MessageID), (int)FilterTableIndex,
                               DS_FilterFileCmd->FilterParmsIndex, DS_FilterFileCmd->FileTableIndex);
@@ -341,7 +341,7 @@ void DS_SetFilterTypeCmd(const CFE_SB_Buffer_t *BufPtr)
 
             DS_AppData.CmdAcceptedCounter++;
 
-            CFE_EVS_SendEvent(DS_FTYPE_CMD_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(DS_FTYPE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                               "FILTER TYPE command: MID = 0x%08lX, index = %d, filter = %d, type = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(DS_FilterTypeCmd->MessageID), (int)FilterTableIndex,
                               DS_FilterTypeCmd->FilterParmsIndex, DS_FilterTypeCmd->FilterType);
@@ -446,7 +446,7 @@ void DS_SetFilterParmsCmd(const CFE_SB_Buffer_t *BufPtr)
 
             DS_AppData.CmdAcceptedCounter++;
 
-            CFE_EVS_SendEvent(DS_PARMS_CMD_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(DS_PARMS_CMD_EID, CFE_EVS_EventType_INFORMATION,
                               "FILTER PARMS command: MID = 0x%08lX, index = %d, filter = %d, N = %d, X = %d, O = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(DS_FilterParmsCmd->MessageID), (int)FilterTableIndex,
                               DS_FilterParmsCmd->FilterParmsIndex, pFilterParms->Algorithm_N, pFilterParms->Algorithm_X,
@@ -514,7 +514,7 @@ void DS_SetDestTypeCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_NTYPE_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_NTYPE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST TYPE command: file table index = %d, filename type = %d",
                           DS_DestTypeCmd->FileTableIndex, DS_DestTypeCmd->FileNameType);
     }
@@ -577,7 +577,7 @@ void DS_SetDestStateCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_STATE_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_STATE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST STATE command: file table index = %d, file state = %d", DS_DestStateCmd->FileTableIndex,
                           DS_DestStateCmd->EnableState);
     }
@@ -633,7 +633,7 @@ void DS_SetDestPathCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_PATH_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_PATH_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST PATH command: file table index = %d, pathname = '%s'",
                           (int)DS_DestPathCmd->FileTableIndex, DS_DestPathCmd->Pathname);
     }
@@ -688,7 +688,7 @@ void DS_SetDestBaseCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_BASE_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_BASE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST BASE command: file table index = %d, base filename = '%s'",
                           (int)DS_DestBaseCmd->FileTableIndex, DS_DestBaseCmd->Basename);
     }
@@ -743,7 +743,7 @@ void DS_SetDestExtCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_EXT_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_EXT_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST EXT command: file table index = %d, extension = '%s'",
                           (int)DS_DestExtCmd->FileTableIndex, DS_DestExtCmd->Extension);
     }
@@ -807,7 +807,7 @@ void DS_SetDestSizeCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_SIZE_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_SIZE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST SIZE command: file table index = %d, size limit = %d",
                           (int)DS_DestSizeCmd->FileTableIndex, (int)DS_DestSizeCmd->MaxFileSize);
     }
@@ -871,7 +871,7 @@ void DS_SetDestAgeCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_AGE_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_AGE_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST AGE command: file table index = %d, age limit = %d", (int)DS_DestAgeCmd->FileTableIndex,
                           (int)DS_DestAgeCmd->MaxFileAge);
     }
@@ -948,7 +948,7 @@ void DS_SetDestCountCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_SEQ_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_SEQ_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "DEST COUNT command: file table index = %d, sequence count = %d",
                           (int)DS_DestCountCmd->FileTableIndex, (int)DS_DestCountCmd->SequenceCount);
     }
@@ -990,7 +990,7 @@ void DS_CloseFileCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_CLOSE_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE command: file table index = %d",
+        CFE_EVS_SendEvent(DS_CLOSE_CMD_EID, CFE_EVS_EventType_INFORMATION, "DEST CLOSE command: file table index = %d",
                           (int)DS_CloseFileCmd->FileTableIndex);
     }
 }
@@ -1019,7 +1019,7 @@ void DS_CloseAllCmd(const CFE_SB_Buffer_t *BufPtr)
 
     DS_AppData.CmdAcceptedCounter++;
 
-    CFE_EVS_SendEvent(DS_CLOSE_ALL_CMD_EID, CFE_EVS_EventType_DEBUG, "DEST CLOSE ALL command");
+    CFE_EVS_SendEvent(DS_CLOSE_ALL_CMD_EID, CFE_EVS_EventType_INFORMATION, "DEST CLOSE ALL command");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1039,7 +1039,7 @@ void DS_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
     */
     DS_AppData.CmdAcceptedCounter++;
 
-    CFE_EVS_SendEvent(DS_GET_FILE_INFO_CMD_EID, CFE_EVS_EventType_DEBUG, "GET FILE INFO command");
+    CFE_EVS_SendEvent(DS_GET_FILE_INFO_CMD_EID, CFE_EVS_EventType_INFORMATION, "GET FILE INFO command");
 
     /*
     ** Initialize file info telemetry packet...
@@ -1198,7 +1198,7 @@ void DS_AddMIDCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_ADD_MID_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_ADD_MID_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "ADD MID command: MID = 0x%08lX, filter index = %d, hash index = %d",
                           (unsigned long)CFE_SB_MsgIdToValue(DS_AddMidCmd->MessageID), (int)FilterTableIndex,
                           (int)HashTableIndex);
@@ -1292,7 +1292,7 @@ void DS_RemoveMIDCmd(const CFE_SB_Buffer_t *BufPtr)
 
         DS_AppData.CmdAcceptedCounter++;
 
-        CFE_EVS_SendEvent(DS_REMOVE_MID_CMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(DS_REMOVE_MID_CMD_EID, CFE_EVS_EventType_INFORMATION,
                           "REMOVE MID command: MID = 0x%08lX, filter index = %d, hash index = %d",
                           (unsigned long)CFE_SB_MsgIdToValue(DS_RemoveMidCmd->MessageID), (int)FilterTableIndex,
                           (int)HashTableIndex);

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -115,7 +115,7 @@ void DS_SetAppStateCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_ENADIS_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_AppStateCmd_t), "DS_AppStateCmd_t is 32-bit aligned");
@@ -167,7 +167,7 @@ void DS_SetFilterFileCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FILE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterFileCmd_t), "DS_FilterFileCmd_t is 32-bit aligned");
@@ -297,7 +297,7 @@ void DS_SetFilterTypeCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_FTYPE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterTypeCmd_t), "DS_FilterTypeCmd_t is 32-bit aligned");
@@ -427,7 +427,7 @@ void DS_SetFilterParmsCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_PARMS_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_FilterParmsCmd_t), "DS_FilterParmsCmd_t is 32-bit aligned");
@@ -557,7 +557,7 @@ void DS_SetDestTypeCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_NTYPE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestTypeCmd_t), "DS_DestTypeCmd_t is 32-bit aligned");
@@ -645,7 +645,7 @@ void DS_SetDestStateCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_STATE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestStateCmd_t), "DS_DestStateCmd_t is 32-bit aligned");
@@ -732,7 +732,7 @@ void DS_SetDestPathCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_PATH_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestPathCmd_t), "DS_DestPathCmd_t is 32-bit aligned");
@@ -799,7 +799,7 @@ void DS_SetDestBaseCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_BASE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestBaseCmd_t), "DS_DestBaseCmd_t is 32-bit aligned");
@@ -867,7 +867,7 @@ void DS_SetDestExtCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_EXT_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestExtCmd_t), "DS_DestExtCmd_t is 32-bit aligned");
@@ -932,7 +932,7 @@ void DS_SetDestSizeCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_SIZE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestSizeCmd_t), "DS_DestSizeCmd_t is 32-bit aligned");
@@ -1021,7 +1021,7 @@ void DS_SetDestAgeCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_AGE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestAgeCmd_t), "DS_DestAgeCmd_t is 32-bit aligned");
@@ -1111,7 +1111,7 @@ void DS_SetDestCountCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_SEQ_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_DestCountCmd_t), "DS_DestCountCmd_t is 32-bit aligned");
@@ -1206,7 +1206,7 @@ void DS_CloseFileCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_CLOSE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_STUB_COUNT(DS_FileUpdateHeader, 1);
     UtAssert_STUB_COUNT(DS_FileCloseDest, 1);
@@ -1239,7 +1239,7 @@ void DS_CloseFileCmd_Test_NominalAlreadyClosed(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_CLOSE_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_STUB_COUNT(DS_FileUpdateHeader, 0);
     UtAssert_STUB_COUNT(DS_FileCloseDest, 0);
@@ -1288,7 +1288,7 @@ void DS_CloseAllCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_CLOSE_ALL_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseAllCmd_t), "DS_CloseAllCmd_t is 32-bit aligned");
@@ -1312,7 +1312,7 @@ void DS_CloseAllCmd_Test_CloseAll(void)
     UtAssert_STUB_COUNT(DS_FileUpdateHeader, DS_DEST_FILE_CNT);
     UtAssert_STUB_COUNT(DS_FileCloseDest, DS_DEST_FILE_CNT);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_CLOSE_ALL_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_BOOL_TRUE(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_CloseAllCmd_t));
@@ -1342,7 +1342,7 @@ void DS_GetFileInfoCmd_Test_EnabledOpen(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_GET_FILE_INFO_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(TLM_STRUCT_DATA_IS_32_ALIGNED(DS_FileInfoPkt_t), "DS_FileInfoPkt_t is 32-bit aligned");
@@ -1372,7 +1372,7 @@ void DS_GetFileInfoCmd_Test_DisabledClosed(void)
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_GET_FILE_INFO_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     /* Generates 1 event message we don't care about in this test */
@@ -1433,7 +1433,7 @@ void DS_AddMIDCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_ADD_MID_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 }
 
 void DS_AddMIDCmd_Test_InvalidMessageID(void)
@@ -1565,7 +1565,7 @@ void DS_RemoveMIDCmd_Test_Nominal(void)
     UtAssert_STUB_COUNT(DS_TableCreateHash, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_REMOVE_MID_CMD_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 }
 
 void DS_RemoveMIDCmd_Test_InvalidMessageID(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #107
  - Updates command events (except Reset - see note below) to `INFO` type rather than `DEBUG` which is the nominal pattern across cFE/cFS although currently there are a couple of apps that don't comply, and a couple of cFE components that only partially comply.

**Note:** cFE and most (but not all) apps leave the Reset command as `DEBUG` - should this remain the case, or should it be changed as well to `INFO`  as the operator might still want to be informed that the Reset command occurred successfully when `DEBUG` events are turned off.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Align command event types to cFS guidelines as per cFE Developer's Guide [s7.2](https://github.com/nasa/cFE/blob/main/docs/cFE%20Application%20Developers%20Guide.md#72-event-types)

**Contributor Info**
Avi Weiss @thnkslprpt