### PR TITLE
Fix #111: Use correct length filename for too large test

### DIFF
--- a/unit-test/ds_file_tests.c
+++ b/unit-test/ds_file_tests.c
@@ -960,12 +960,15 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_MoveError(void)
 void DS_FileCloseDest_Test_PlatformConfigMoveFiles_FilenameTooLarge(void)
 {
     int32 FileIndex = 0;
-
+    const char DirName[] = "directory1/";
+    
     /* Set up the handle */
     OS_OpenCreate(&DS_AppData.FileStatus[FileIndex].FileHandle, NULL, 0, 0);
-
-    strncpy(DS_AppData.FileStatus[FileIndex].FileName, "directory1/filenamefilenamefilenamefilenamefilenamefilename",
-            sizeof(DS_AppData.FileStatus[FileIndex].FileName));
+    
+    size_t DirNameLen = sizeof(DirName);
+    strncpy(DS_AppData.FileStatus[FileIndex].FileName, DirName, DirNameLen);
+    memset(&DS_AppData.FileStatus[FileIndex].FileName[DirNameLen-1], 'f', DS_TOTAL_FNAME_BUFSIZE - DirNameLen);
+    DS_AppData.FileStatus[FileIndex].FileName[DS_TOTAL_FNAME_BUFSIZE-1] = '\0';
     strncpy(DS_AppData.DestFileTblPtr->File[FileIndex].Movename, "directory2/movename/",
             sizeof(DS_AppData.DestFileTblPtr->File[FileIndex].Movename));
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes https://github.com/nasa/DS/issues/111

**Testing performed**
See reproduction steps from linked issue

**Expected behavior changes**
Tests should pass if OSAL_CONFIG_MAX_PATH_LEN is increased

**System(s) tested on**
- Hardware: Intel Xeon CPU E5-2687W v4 @ 3.00GHz
- OS: CentOS 7
- Versions: trunk DS, cFE Draco rc-3

**Additional context**
Add any other context about the contribution here.
Related cFE issue: https://github.com/nasa/cFE/issues/2372


**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
Isaac Rowe, NASA JSC/Jacobs Technology
