### PR TITLE
Fix #125, Adds utassert macro for logging function calls

### DIFF
--- a/unit-test/ds_app_tests.c
+++ b/unit-test/ds_app_tests.c
@@ -75,7 +75,7 @@ void DS_AppMain_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &forced_Size, sizeof(forced_Size), false);
 
     /* Execute the function being tested */
-    DS_AppMain();
+    UtAssert_VOIDCALL(DS_AppMain());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -95,7 +95,7 @@ void DS_AppMain_Test_AppInitializeError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_EVS_Register), 1, -1);
 
     /* Execute the function being tested */
-    DS_AppMain();
+    UtAssert_VOIDCALL(DS_AppMain());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -115,7 +115,7 @@ void DS_AppMain_Test_SBError(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_PIPE_RD_ERR);
 
     /* Execute the function being tested */
-    DS_AppMain();
+    UtAssert_VOIDCALL(DS_AppMain());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
@@ -135,7 +135,7 @@ void DS_AppMain_Test_SBTimeout(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_TIME_OUT);
 
     /* Execute the function being tested */
-    DS_AppMain();
+    UtAssert_VOIDCALL(DS_AppMain());
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
@@ -259,7 +259,7 @@ void DS_AppSendHkCmd_Test(void)
     }
 
     /* Execute the function being tested */
-    DS_AppSendHkCmd();
+    UtAssert_VOIDCALL(DS_AppSendHkCmd());
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[0].FileRate, 99 / DS_SECS_PER_HK_CYCLE);
@@ -293,7 +293,7 @@ void DS_AppSendHkCmd_Test_SnprintfFail(void)
     UT_SetDeferredRetcode(UT_KEY(stub_snprintf), 1, -1);
 
     /* Execute the function being tested */
-    DS_AppSendHkCmd();
+    UtAssert_VOIDCALL(DS_AppSendHkCmd());
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[0].FileRate, 99 / DS_SECS_PER_HK_CYCLE);
@@ -329,7 +329,7 @@ void DS_AppSendHkCmd_Test_TblFail(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetInfo), -1);
 
     /* Execute the function being tested */
-    DS_AppSendHkCmd();
+    UtAssert_VOIDCALL(DS_AppSendHkCmd());
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[0].FileRate, 99 / DS_SECS_PER_HK_CYCLE);
@@ -363,7 +363,7 @@ void DS_AppStorePacket_Test_Nominal(void)
     DS_AppData.AppEnableState = DS_ENABLED;
 
     /* Execute the function being tested */
-    DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results -- IgnoredPktCounter increments in call to DS_FileStorePacket() */
     UtAssert_UINT32_EQ(DS_AppData.IgnoredPktCounter, 0);
@@ -387,7 +387,7 @@ void DS_AppStorePacket_Test_DSDisabled(void)
     DS_AppData.AppEnableState = DS_DISABLED;
 
     /* Execute the function being tested */
-    DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.DisabledPktCounter, 1);
@@ -410,7 +410,7 @@ void DS_AppStorePacket_Test_FilterTableNotLoaded(void)
     DS_AppData.FilterTblPtr   = 0;
 
     /* Execute the function being tested */
-    DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.IgnoredPktCounter, 1);
@@ -433,7 +433,7 @@ void DS_AppStorePacket_Test_DestFileTableNotLoaded(void)
     DS_AppData.DestFileTblPtr = 0;
 
     /* Execute the function being tested */
-    DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.IgnoredPktCounter, 1);

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -55,7 +55,7 @@
 void DS_NoopCmd_Test_Nominal(void)
 {
     /* Execute the function being tested */
-    DS_NoopCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_NoopCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -71,7 +71,7 @@ void DS_NoopCmd_Test_Nominal(void)
 void DS_ResetCountersCmd_Test_Nominal(void)
 {
     /* Execute the function being tested */
-    DS_ResetCountersCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_ResetCountersCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_ZERO(DS_AppData.CmdAcceptedCounter);
@@ -106,7 +106,7 @@ void DS_SetAppStateCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyState), true);
 
     /* Execute the function being tested */
-    DS_SetAppStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetAppStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(DS_AppData.CmdRejectedCounter, 0);
@@ -128,7 +128,7 @@ void DS_SetAppStateCmd_Test_InvalidAppState(void)
     CmdPayload->EnableState = 99;
 
     /* Execute the function being tested */
-    DS_SetAppStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetAppStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -154,7 +154,7 @@ void DS_SetFilterFileCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), forced_FilterTableIndex);
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -180,7 +180,7 @@ void DS_SetFilterFileCmd_Test_InvalidMessageID(void)
     CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -198,7 +198,7 @@ void DS_SetFilterFileCmd_Test_InvalidFilterParametersIndex(void)
     CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -217,7 +217,7 @@ void DS_SetFilterFileCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex   = 99;
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -241,7 +241,7 @@ void DS_SetFilterFileCmd_Test_FilterTableNotLoaded(void)
     DS_AppData.FilterTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -265,7 +265,7 @@ void DS_SetFilterFileCmd_Test_MessageIDNotInFilterTable(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_SetFilterFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -288,7 +288,7 @@ void DS_SetFilterTypeCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyType), true);
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -310,7 +310,7 @@ void DS_SetFilterTypeCmd_Test_InvalidMessageID(void)
     CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -328,7 +328,7 @@ void DS_SetFilterTypeCmd_Test_InvalidFilterParametersIndex(void)
     CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -347,7 +347,7 @@ void DS_SetFilterTypeCmd_Test_InvalidFilterType(void)
     CmdPayload->FilterType       = false;
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -371,7 +371,7 @@ void DS_SetFilterTypeCmd_Test_FilterTableNotLoaded(void)
     DS_AppData.FilterTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -393,7 +393,7 @@ void DS_SetFilterTypeCmd_Test_MessageIDNotInFilterTable(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_SetFilterTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -416,7 +416,7 @@ void DS_SetFilterParmsCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyParms), true);
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -440,7 +440,7 @@ void DS_SetFilterParmsCmd_Test_InvalidMessageID(void)
     CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -458,7 +458,7 @@ void DS_SetFilterParmsCmd_Test_InvalidFilterParametersIndex(void)
     CmdPayload->FilterParmsIndex = DS_FILTERS_PER_PACKET;
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -481,7 +481,7 @@ void DS_SetFilterParmsCmd_Test_InvalidFilterAlgorithm(void)
     DS_AppData.FilterTblPtr->Packet->MessageID = DS_UT_MID_1;
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -504,7 +504,7 @@ void DS_SetFilterParmsCmd_Test_FilterTableNotLoaded(void)
     DS_AppData.FilterTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -527,7 +527,7 @@ void DS_SetFilterParmsCmd_Test_MessageIDNotInFilterTable(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_SetFilterParmsCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetFilterParmsCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -548,7 +548,7 @@ void DS_SetDestTypeCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyType), true);
 
     /* Execute the function being tested */
-    DS_SetDestTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -570,7 +570,7 @@ void DS_SetDestTypeCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_SetDestTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -590,7 +590,7 @@ void DS_SetDestTypeCmd_Test_InvalidFilenameType(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -613,7 +613,7 @@ void DS_SetDestTypeCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyType), true);
 
     /* Execute the function being tested */
-    DS_SetDestTypeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestTypeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -634,7 +634,7 @@ void DS_SetDestStateCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyState), true);
 
     /* Execute the function being tested */
-    DS_SetDestStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -658,7 +658,7 @@ void DS_SetDestStateCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_SetDestStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -678,7 +678,7 @@ void DS_SetDestStateCmd_Test_InvalidFileState(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -700,7 +700,7 @@ void DS_SetDestStateCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyState), true);
 
     /* Execute the function being tested */
-    DS_SetDestStateCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestStateCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -720,7 +720,7 @@ void DS_SetDestPathCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestPathCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestPathCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -745,7 +745,7 @@ void DS_SetDestPathCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_SetDestPathCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestPathCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -767,7 +767,7 @@ void DS_SetDestPathCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestPathCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestPathCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -787,7 +787,7 @@ void DS_SetDestBaseCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestBaseCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestBaseCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -812,7 +812,7 @@ void DS_SetDestBaseCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_SetDestBaseCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestBaseCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -834,7 +834,7 @@ void DS_SetDestBaseCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestBaseCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestBaseCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -854,7 +854,7 @@ void DS_SetDestExtCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestExtCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestExtCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -880,7 +880,7 @@ void DS_SetDestExtCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_SetDestExtCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestExtCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -902,7 +902,7 @@ void DS_SetDestExtCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestExtCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestExtCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -923,7 +923,7 @@ void DS_SetDestSizeCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifySize), true);
 
     /* Execute the function being tested */
-    DS_SetDestSizeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestSizeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -946,7 +946,7 @@ void DS_SetDestSizeCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->MaxFileSize    = 100000000;
 
     /* Execute the function being tested */
-    DS_SetDestSizeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestSizeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -968,7 +968,7 @@ void DS_SetDestSizeCmd_Test_InvalidFileSizeLimit(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestSizeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestSizeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -991,7 +991,7 @@ void DS_SetDestSizeCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifySize), true);
 
     /* Execute the function being tested */
-    DS_SetDestSizeCmd(&UT_CmdBuf.Buf);
+   UtAssert_VOIDCALL(DS_SetDestSizeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1012,7 +1012,7 @@ void DS_SetDestAgeCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyAge), true);
 
     /* Execute the function being tested */
-    DS_SetDestAgeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestAgeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1035,7 +1035,7 @@ void DS_SetDestAgeCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->MaxFileAge     = 1000;
 
     /* Execute the function being tested */
-    DS_SetDestAgeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestAgeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1057,7 +1057,7 @@ void DS_SetDestAgeCmd_Test_InvalidFileAgeLimit(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestAgeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestAgeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1080,7 +1080,7 @@ void DS_SetDestAgeCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyAge), true);
 
     /* Execute the function being tested */
-    DS_SetDestAgeCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestAgeCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1101,7 +1101,7 @@ void DS_SetDestCountCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyCount), true);
 
     /* Execute the function being tested */
-    DS_SetDestCountCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestCountCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1125,7 +1125,7 @@ void DS_SetDestCountCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->SequenceCount  = 1;
 
     /* Execute the function being tested */
-    DS_SetDestCountCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestCountCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1147,7 +1147,7 @@ void DS_SetDestCountCmd_Test_InvalidFileSequenceCount(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_SetDestCountCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestCountCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1170,7 +1170,7 @@ void DS_SetDestCountCmd_Test_FileTableNotLoaded(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyCount), true);
 
     /* Execute the function being tested */
-    DS_SetDestCountCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_SetDestCountCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1199,7 +1199,7 @@ void DS_CloseFileCmd_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_CloseFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_CloseFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1232,7 +1232,7 @@ void DS_CloseFileCmd_Test_NominalAlreadyClosed(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableVerifyFileIndex), true);
 
     /* Execute the function being tested */
-    DS_CloseFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_CloseFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1257,7 +1257,7 @@ void DS_CloseFileCmd_Test_InvalidFileTableIndex(void)
     CmdPayload->FileTableIndex = 99;
 
     /* Execute the function being tested */
-    DS_CloseFileCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_CloseFileCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1281,7 +1281,7 @@ void DS_CloseAllCmd_Test_Nominal(void)
 #endif
 
     /* Execute the function being tested */
-    DS_CloseAllCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_CloseAllCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1334,7 +1334,7 @@ void DS_GetFileInfoCmd_Test_EnabledOpen(void)
     }
 
     /* Execute the function being tested */
-    DS_GetFileInfoCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_GetFileInfoCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1367,7 +1367,7 @@ void DS_GetFileInfoCmd_Test_DisabledClosed(void)
     DS_AppData.DestFileTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_GetFileInfoCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_GetFileInfoCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1401,7 +1401,7 @@ void DS_AddMIDCmd_Test_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(DS_TableFindMsgID), 1, 0);
 
     /* Execute the function being tested */
-    DS_AddMIDCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AddMIDCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdAcceptedCounter, 1);
@@ -1443,7 +1443,7 @@ void DS_AddMIDCmd_Test_InvalidMessageID(void)
     CmdPayload->MessageID = CFE_SB_INVALID_MSG_ID;
 
     /* Execute the function being tested */
-    DS_AddMIDCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AddMIDCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1463,7 +1463,7 @@ void DS_AddMIDCmd_Test_FilterTableNotLoaded(void)
     DS_AppData.FilterTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_AddMIDCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AddMIDCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1483,7 +1483,7 @@ void DS_AddMIDCmd_Test_MIDAlreadyInFilterTable(void)
     UT_SetDeferredRetcode(UT_KEY(DS_TableFindMsgID), 1, 1);
 
     /* Execute the function being tested */
-    DS_AddMIDCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AddMIDCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);
@@ -1503,7 +1503,7 @@ void DS_AddMIDCmd_Test_FilterTableFull(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_AddMIDCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AddMIDCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);

--- a/unit-test/ds_dispatch_tests.c
+++ b/unit-test/ds_dispatch_tests.c
@@ -68,7 +68,7 @@ void DS_AppProcessMsg_Test_CmdStore(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), 1);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     /* an attempt was made to store this packet */
     UtAssert_STUB_COUNT(DS_AppStorePacket, 1);
@@ -84,7 +84,7 @@ void DS_AppProcessMsg_Test_CmdNoStore(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -103,7 +103,7 @@ void DS_AppProcessMsg_Test_HKStore(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), 1);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     UtAssert_STUB_COUNT(DS_AppSendHkCmd, 1);
 
@@ -121,7 +121,7 @@ void DS_AppProcessMsg_Test_HKNoStore(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     UtAssert_STUB_COUNT(DS_AppSendHkCmd, 1);
 
@@ -134,7 +134,7 @@ void DS_AppProcessMsg_Test_HKInvalidRequest(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_SEND_HK_MID), 0, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -147,7 +147,7 @@ void DS_AppProcessMsg_Test_UnknownMID(void)
     DS_Dispatch_Test_SetupMsg(DS_UT_MID_1, 0, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessMsg(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessMsg(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -161,7 +161,7 @@ void DS_AppProcessCmd_Test_Noop(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_NOOP_CC, sizeof(DS_NoopCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_NoopCmd, 1);
@@ -170,7 +170,7 @@ void DS_AppProcessCmd_Test_Noop(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_NOOP_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_NoopCmd, 1);
@@ -181,7 +181,7 @@ void DS_AppProcessCmd_Test_Reset(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_RESET_COUNTERS_CC, sizeof(DS_ResetCountersCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_ResetCountersCmd, 1);
@@ -190,7 +190,7 @@ void DS_AppProcessCmd_Test_Reset(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_RESET_COUNTERS_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_ResetCountersCmd, 1);
@@ -201,7 +201,7 @@ void DS_AppProcessCmd_Test_SetAppState(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_APP_STATE_CC, sizeof(DS_AppStateCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetAppStateCmd, 1);
@@ -210,7 +210,7 @@ void DS_AppProcessCmd_Test_SetAppState(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_APP_STATE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetAppStateCmd, 1);
@@ -221,7 +221,7 @@ void DS_AppProcessCmd_Test_SetFilterFile(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_FILE_CC, sizeof(DS_FilterFileCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetFilterFileCmd, 1);
@@ -230,7 +230,7 @@ void DS_AppProcessCmd_Test_SetFilterFile(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_FILE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetFilterFileCmd, 1);
@@ -241,7 +241,7 @@ void DS_AppProcessCmd_Test_SetFilterType(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_TYPE_CC, sizeof(DS_FilterTypeCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetFilterTypeCmd, 1);
@@ -250,7 +250,7 @@ void DS_AppProcessCmd_Test_SetFilterType(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_TYPE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetFilterTypeCmd, 1);
@@ -261,7 +261,7 @@ void DS_AppProcessCmd_Test_SetFilterParms(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_PARMS_CC, sizeof(DS_FilterParmsCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetFilterParmsCmd, 1);
@@ -270,7 +270,7 @@ void DS_AppProcessCmd_Test_SetFilterParms(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_FILTER_PARMS_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetFilterParmsCmd, 1);
@@ -281,7 +281,7 @@ void DS_AppProcessCmd_Test_SetDestType(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_TYPE_CC, sizeof(DS_DestTypeCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestTypeCmd, 1);
@@ -290,7 +290,7 @@ void DS_AppProcessCmd_Test_SetDestType(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_TYPE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestTypeCmd, 1);
@@ -301,7 +301,7 @@ void DS_AppProcessCmd_Test_SetDestState(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_STATE_CC, sizeof(DS_DestStateCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestStateCmd, 1);
@@ -310,7 +310,7 @@ void DS_AppProcessCmd_Test_SetDestState(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_STATE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestStateCmd, 1);
@@ -321,7 +321,7 @@ void DS_AppProcessCmd_Test_SetDestPath(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_PATH_CC, sizeof(DS_DestPathCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestPathCmd, 1);
@@ -330,7 +330,7 @@ void DS_AppProcessCmd_Test_SetDestPath(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_PATH_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestPathCmd, 1);
@@ -341,7 +341,7 @@ void DS_AppProcessCmd_Test_SetDestBase(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_BASE_CC, sizeof(DS_DestBaseCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestBaseCmd, 1);
@@ -350,7 +350,7 @@ void DS_AppProcessCmd_Test_SetDestBase(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_BASE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestBaseCmd, 1);
@@ -361,7 +361,7 @@ void DS_AppProcessCmd_Test_SetDestExt(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_EXT_CC, sizeof(DS_DestExtCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestExtCmd, 1);
@@ -370,7 +370,7 @@ void DS_AppProcessCmd_Test_SetDestExt(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_EXT_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestExtCmd, 1);
@@ -381,7 +381,7 @@ void DS_AppProcessCmd_Test_SetDestSize(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_SIZE_CC, sizeof(DS_DestSizeCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestSizeCmd, 1);
@@ -390,7 +390,7 @@ void DS_AppProcessCmd_Test_SetDestSize(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_SIZE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestSizeCmd, 1);
@@ -401,7 +401,7 @@ void DS_AppProcessCmd_Test_SetDestAge(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_AGE_CC, sizeof(DS_DestAgeCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestAgeCmd, 1);
@@ -410,7 +410,7 @@ void DS_AppProcessCmd_Test_SetDestAge(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_AGE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestAgeCmd, 1);
@@ -421,7 +421,7 @@ void DS_AppProcessCmd_Test_SetDestCount(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_COUNT_CC, sizeof(DS_DestCountCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_SetDestCountCmd, 1);
@@ -430,7 +430,7 @@ void DS_AppProcessCmd_Test_SetDestCount(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_SET_DEST_COUNT_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_SetDestCountCmd, 1);
@@ -441,7 +441,7 @@ void DS_AppProcessCmd_Test_CloseFile(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_CLOSE_FILE_CC, sizeof(DS_CloseFileCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CloseFileCmd, 1);
@@ -450,7 +450,7 @@ void DS_AppProcessCmd_Test_CloseFile(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_CLOSE_FILE_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_CloseFileCmd, 1);
@@ -461,7 +461,7 @@ void DS_AppProcessCmd_Test_GetFileInfo(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_GET_FILE_INFO_CC, sizeof(DS_GetFileInfoCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_GetFileInfoCmd, 1);
@@ -470,7 +470,7 @@ void DS_AppProcessCmd_Test_GetFileInfo(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_GET_FILE_INFO_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_GetFileInfoCmd, 1);
@@ -481,7 +481,7 @@ void DS_AppProcessCmd_Test_AddMID(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_ADD_MID_CC, sizeof(DS_AddMidCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_AddMIDCmd, 1);
@@ -490,7 +490,7 @@ void DS_AppProcessCmd_Test_AddMID(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_ADD_MID_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_AddMIDCmd, 1);
@@ -501,7 +501,7 @@ void DS_AppProcessCmd_Test_RemoveMID(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_REMOVE_MID_CC, sizeof(DS_RemoveMidCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_RemoveMIDCmd, 1);
@@ -510,7 +510,7 @@ void DS_AppProcessCmd_Test_RemoveMID(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_REMOVE_MID_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_RemoveMIDCmd, 1);
@@ -521,7 +521,7 @@ void DS_AppProcessCmd_Test_CloseAll(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_CLOSE_ALL_CC, sizeof(DS_CloseAllCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(DS_CloseAllCmd, 1);
@@ -530,7 +530,7 @@ void DS_AppProcessCmd_Test_CloseAll(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), DS_CLOSE_ALL_CC, 1);
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Should NOT have invoked the handler this time */
     UtAssert_STUB_COUNT(DS_CloseAllCmd, 1);
@@ -541,7 +541,7 @@ void DS_AppProcessCmd_Test_InvalidCommandCode(void)
     DS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(DS_CMD_MID), 99, sizeof(DS_CloseAllCmd_t));
 
     /* Execute the function being tested */
-    DS_AppProcessCmd(&UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_AppProcessCmd(&UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.CmdRejectedCounter, 1);

--- a/unit-test/ds_file_tests.c
+++ b/unit-test/ds_file_tests.c
@@ -97,7 +97,7 @@ void DS_FileStorePacket_Test_Nominal(void)
     DS_AppData.FileStatus[0].FileSize                           = 0;
 
     /* Execute the function being tested */
-    DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.PassedPktCounter, 1);
@@ -125,7 +125,7 @@ void DS_FileStorePacket_Test_PacketNotInTable(void)
     UT_SetDefaultReturnValue(UT_KEY(DS_TableFindMsgID), DS_INDEX_NONE);
 
     /* Execute the function being tested */
-    DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_INT32_EQ(DS_AppData.IgnoredPktCounter, 1);
@@ -158,7 +158,7 @@ void DS_FileStorePacket_Test_PassedFilterFalse(void)
     DS_AppData.FileStatus[0].FileState                       = DS_ENABLED;
 
     /* Execute the function being tested */
-    DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
@@ -189,7 +189,7 @@ void DS_FileStorePacket_Test_DisabledDest(void)
     DS_AppData.FileStatus[0].FileState                       = DS_DISABLED;
 
     /* Execute the function being tested */
-    DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
@@ -221,7 +221,7 @@ void DS_FileStorePacket_Test_InvalidIndex(void)
     DS_AppData.FileStatus[0].FileState                          = DS_ENABLED;
 
     /* Execute the function being tested */
-    DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileStorePacket(MessageID, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FilteredPktCounter, 1);
@@ -245,7 +245,7 @@ void DS_FileSetupWrite_Test_Nominal(void)
     DS_AppData.FileStatus[FileIndex].FileSize              = 3;
 
     /* Execute the function being tested */
-    DS_FileSetupWrite(FileIndex, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileSetupWrite(FileIndex, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -304,7 +304,7 @@ void DS_FileSetupWrite_Test_MaxFileSizeExceeded(void)
 #endif
 
     /* Execute the function being tested */
-    DS_FileSetupWrite(FileIndex, &UT_CmdBuf.Buf);
+    UtAssert_VOIDCALL(DS_FileSetupWrite(FileIndex, &UT_CmdBuf.Buf));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -356,7 +356,7 @@ void DS_FileWriteData_Test_Error(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].Movename[0] = '\0';
 
     /* Execute the function being tested */
-    DS_FileWriteData(FileIndex, &UT_CmdBuf.Buf, DataLength);
+    UtAssert_VOIDCALL(DS_FileWriteData(FileIndex, &UT_CmdBuf.Buf, DataLength));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -372,7 +372,7 @@ void DS_FileWriteHeader_Test_PlatformConfigCFE_Nominal(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].FileNameType = 1;
 
     /* Execute the function being tested */
-    DS_FileWriteHeader(FileIndex);
+    UtAssert_VOIDCALL(DS_FileWriteHeader(FileIndex));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -397,7 +397,7 @@ void DS_FileWriteHeader_Test_PrimaryHeaderError(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_WriteHeader), -1);
 
     /* Execute the function being tested */
-    DS_FileWriteHeader(FileIndex);
+    UtAssert_VOIDCALL(DS_FileWriteHeader(FileIndex));
 
     /* Verify results */
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
@@ -418,7 +418,7 @@ void DS_FileWriteHeader_Test_SecondaryHeaderError(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].Movename[0] = '\0';
 
     /* Set to generate secondary header error */
-    UT_SetDefaultReturnValue(UT_KEY(OS_write), -1);
+    UtAssert_VOIDCALL(UT_SetDefaultReturnValue(UT_KEY(OS_write), -1));
 
     /* Execute the function being tested */
     DS_FileWriteHeader(FileIndex);
@@ -445,7 +445,7 @@ void DS_FileWriteError_Test(void)
     strncpy(DS_AppData.FileStatus[FileIndex].FileName, "filename", sizeof(DS_AppData.FileStatus[FileIndex].FileName));
 
     /* Execute the function being tested */
-    DS_FileWriteError(FileIndex, DataLength, WriteResult);
+    UtAssert_VOIDCALL(DS_FileWriteError(FileIndex, DataLength, WriteResult));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileWriteErrCounter, 1);
@@ -472,7 +472,7 @@ void DS_FileCreateDest_Test_Nominal(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].FileNameType = DS_BY_COUNT;
 
     /* Execute the function being tested */
-    DS_FileCreateDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateDest(FileIndex));
 
     /* Verify results */
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -518,7 +518,7 @@ void DS_FileCreateDest_Test_NominalRollover(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].FileNameType  = DS_BY_COUNT;
     DS_AppData.DestFileTblPtr->File[FileIndex].SequenceCount = 3;
     /* Execute the function being tested */
-    DS_FileCreateDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateDest(FileIndex));
 
     /* Verify results */
 #if DS_FILE_HEADER_TYPE == DS_FILE_HEADER_CFE
@@ -551,7 +551,7 @@ void DS_FileCreateDest_Test_Error(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), -1);
 
     /* Execute the function being tested */
-    DS_FileCreateDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateDest(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileWriteErrCounter, 1);
@@ -580,7 +580,7 @@ void DS_FileCreateDest_Test_ClosedFileHandle(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_WriteHeader), -1);
 
     /* Execute the function being tested */
-    DS_FileCreateDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateDest(FileIndex));
 
     /* Verify results */
     UtAssert_INT32_EQ(DS_AppData.FileWriteCounter, 1);
@@ -604,7 +604,7 @@ void DS_FileCreateName_Test_Nominal(void)
     DS_AppData.FileStatus[FileIndex].FileCount = 1;
 
     /* Execute the function being tested */
-    DS_FileCreateName(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateName(FileIndex));
 
     /* Verify results */
     UtAssert_STRINGBUF_EQ(DS_AppData.FileStatus[FileIndex].FileName, sizeof(DS_AppData.FileStatus[FileIndex].FileName),
@@ -630,7 +630,7 @@ void DS_FileCreateName_Test_NominalWithSeparator(void)
     DS_AppData.FileStatus[FileIndex].FileCount = 1;
 
     /* Execute the function being tested */
-    DS_FileCreateName(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateName(FileIndex));
 
     /* Verify results */
     UtAssert_STRINGBUF_EQ(DS_AppData.FileStatus[FileIndex].FileName, sizeof(DS_AppData.FileStatus[FileIndex].FileName),
@@ -656,7 +656,7 @@ void DS_FileCreateName_Test_NominalWithPeriod(void)
     DS_AppData.FileStatus[FileIndex].FileCount = 1;
 
     /* Execute the function being tested */
-    DS_FileCreateName(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateName(FileIndex));
 
     /* Verify results */
     UtAssert_STRINGBUF_EQ(DS_AppData.FileStatus[FileIndex].FileName, sizeof(DS_AppData.FileStatus[FileIndex].FileName),
@@ -676,7 +676,7 @@ void DS_FileCreateName_Test_EmptyPath(void)
     DS_AppData.FileStatus[FileIndex].FileCount = 1;
 
     /* Execute the function being tested */
-    DS_FileCreateName(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateName(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileState, DS_DISABLED);
@@ -701,7 +701,7 @@ void DS_FileCreateName_Test_Error(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].Basename[DS_TOTAL_FNAME_BUFSIZE - 1] = '\0';
 
     /* Execute the function being tested */
-    DS_FileCreateName(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCreateName(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileState, DS_DISABLED);
@@ -796,7 +796,7 @@ void DS_FileCreateSequence_Test_ByCount(void)
     memset(Sequence, 0, sizeof(Sequence));
 
     /* Execute the function being tested */
-    DS_FileCreateSequence(Sequence, DS_BY_COUNT, Count);
+    UtAssert_VOIDCALL(DS_FileCreateSequence(Sequence, DS_BY_COUNT, Count));
 
     /* Verify results */
     UtAssert_STRINGBUF_EQ(Sequence, sizeof(Sequence), StrCompare, sizeof(StrCompare));
@@ -847,7 +847,7 @@ void DS_FileCreateSequence_Test_BadFilenameType(void)
     DS_AppData.FileStatus[FileIndex].FileCount = 1;
 
     /* Execute the function being tested */
-    DS_FileCreateSequence(Sequence, 99, DS_AppData.FileStatus[FileIndex].FileCount);
+    UtAssert_VOIDCALL(DS_FileCreateSequence(Sequence, 99, DS_AppData.FileStatus[FileIndex].FileCount));
 
     /* Verify results */
     UtAssert_UINT32_EQ(strncmp(Sequence, "", DS_TOTAL_FNAME_BUFSIZE), 0);
@@ -861,7 +861,7 @@ void DS_FileUpdateHeader_Test_PlatformConfigCFE_Nominal(void)
     int32 FileIndex = 0;
 
     /* Execute the function being tested */
-    DS_FileUpdateHeader(FileIndex);
+    UtAssert_VOIDCALL(DS_FileUpdateHeader(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateCounter, 1);
@@ -878,7 +878,7 @@ void DS_FileUpdateHeader_Test_WriteError(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_write), -1);
 
     /* Execute the function being tested */
-    DS_FileUpdateHeader(FileIndex);
+    UtAssert_VOIDCALL(DS_FileUpdateHeader(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateErrCounter, 1);
@@ -895,7 +895,7 @@ void DS_FileUpdateHeader_Test_PlatformConfigCFE_SeekError(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_lseek), -1);
 
     /* Execute the function being tested */
-    DS_FileUpdateHeader(FileIndex);
+    UtAssert_VOIDCALL(DS_FileUpdateHeader(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileUpdateErrCounter, 1);
@@ -917,7 +917,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_Nominal(void)
             sizeof(DS_AppData.DestFileTblPtr->File[FileIndex].Movename));
 
     /* Execute the function being tested */
-    DS_FileCloseDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCloseDest(FileIndex));
 
     /* Verify results */
     UtAssert_BOOL_FALSE(OS_ObjectIdDefined(DS_AppData.FileStatus[FileIndex].FileHandle));
@@ -945,7 +945,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_MoveError(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_mv), -1);
 
     /* Execute the function being tested */
-    DS_FileCloseDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCloseDest(FileIndex));
 
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 0);
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileSize, 0);
@@ -973,7 +973,7 @@ void DS_FileCloseDest_Test_PlatformConfigMoveFiles_FilenameTooLarge(void)
             sizeof(DS_AppData.DestFileTblPtr->File[FileIndex].Movename));
 
     /* Execute the function being tested */
-    DS_FileCloseDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCloseDest(FileIndex));
 
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 0);
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileSize, 0);
@@ -1018,7 +1018,7 @@ void DS_FileCloseDest_Test_MoveFilesFalse(void)
     OS_OpenCreate(&DS_AppData.FileStatus[FileIndex].FileHandle, NULL, 0, 0);
 
     /* Execute the function being tested */
-    DS_FileCloseDest(FileIndex);
+    UtAssert_VOIDCALL(DS_FileCloseDest(FileIndex));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileHandle, OS_OBJECT_ID_UNDEFINED);
@@ -1047,7 +1047,7 @@ void DS_FileTestAge_Test_Nominal(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].MaxFileAge = 3;
 
     /* Execute the function being tested */
-    DS_FileTestAge(ElapsedSeconds);
+    UtAssert_VOIDCALL(DS_FileTestAge(ElapsedSeconds));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 2);
@@ -1060,7 +1060,7 @@ void DS_FileTestAge_Test_NullTable(void)
     DS_AppData.DestFileTblPtr = NULL;
 
     /* Execute the function being tested */
-    DS_FileTestAge(ElapsedSeconds);
+    UtAssert_VOIDCALL(DS_FileTestAge(ElapsedSeconds));
 
     /* Verify results */
     UtAssert_STUB_COUNT(OS_close, 0);
@@ -1078,7 +1078,7 @@ void DS_FileTestAge_Test_ExceedMaxAge(void)
     DS_AppData.DestFileTblPtr->File[FileIndex].MaxFileAge = 1;
 
     /* Execute the function being tested */
-    DS_FileTestAge(ElapsedSeconds);
+    UtAssert_VOIDCALL(DS_FileTestAge(ElapsedSeconds));
 
     /* Verify results */
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[FileIndex].FileAge, 0);
@@ -1087,7 +1087,6 @@ void DS_FileTestAge_Test_ExceedMaxAge(void)
 
 void DS_IsPacketFiltered_Test_AlgX0(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 2;
     uint16            Alg_N      = 0;
@@ -1095,15 +1094,11 @@ void DS_IsPacketFiltered_Test_AlgX0(void)
     uint16            Alg_O      = 0;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_AlgN0(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 2;
     uint16            Alg_N      = 0;
@@ -1111,15 +1106,11 @@ void DS_IsPacketFiltered_Test_AlgN0(void)
     uint16            Alg_O      = 0;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_AlgNGreaterX(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 2;
     uint16            Alg_N      = 2;
@@ -1127,15 +1118,11 @@ void DS_IsPacketFiltered_Test_AlgNGreaterX(void)
     uint16            Alg_O      = 0;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_Alg0GreaterX(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 2;
     uint16            Alg_N      = 1;
@@ -1143,15 +1130,11 @@ void DS_IsPacketFiltered_Test_Alg0GreaterX(void)
     uint16            Alg_O      = 2;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_Alg0EqualX(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 2;
     uint16            Alg_N      = 1;
@@ -1159,15 +1142,11 @@ void DS_IsPacketFiltered_Test_Alg0EqualX(void)
     uint16            Alg_O      = 1;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_InvalidFilterType(void)
 {
-    bool              Result;
     CFE_MSG_Message_t Message;
     uint16            FilterType = 0xff;
     uint16            Alg_N      = 1;
@@ -1175,15 +1154,11 @@ void DS_IsPacketFiltered_Test_InvalidFilterType(void)
     uint16            Alg_O      = 0;
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_SeqFilter(void)
 {
-    bool                    Result;
     CFE_MSG_Message_t       Message;
     CFE_MSG_SequenceCount_t SeqCnt     = 0;
     uint16                  FilterType = 1;
@@ -1196,15 +1171,11 @@ void DS_IsPacketFiltered_Test_SeqFilter(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSequenceCount), &SeqCnt, sizeof(SeqCnt), false);
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_FALSE(Result);
+    UtAssert_BOOL_FALSE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_TimeFilter1(void)
 {
-    bool               Result;
     CFE_MSG_Message_t  Message;
     CFE_TIME_SysTime_t PacketTime;
     uint16             FilterType = 2;
@@ -1221,15 +1192,11 @@ void DS_IsPacketFiltered_Test_TimeFilter1(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgTime), &PacketTime, sizeof(PacketTime), false);
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_FALSE(Result);
+    UtAssert_BOOL_FALSE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_TimeFilter2(void)
 {
-    bool               Result;
     CFE_MSG_Message_t  Message;
     CFE_TIME_SysTime_t PacketTime;
     uint16             FilterType = 2;
@@ -1246,15 +1213,11 @@ void DS_IsPacketFiltered_Test_TimeFilter2(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgTime), &PacketTime, sizeof(PacketTime), false);
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_IsPacketFiltered_Test_TimeFilter3(void)
 {
-    bool               Result;
     CFE_MSG_Message_t  Message;
     CFE_TIME_SysTime_t PacketTime;
     uint16             FilterType = 2;
@@ -1271,10 +1234,7 @@ void DS_IsPacketFiltered_Test_TimeFilter3(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgTime), &PacketTime, sizeof(PacketTime), false);
 
     /* Execute the function being tested */
-    Result = DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O);
-
-    /* Verify results */
-    UtAssert_BOOL_TRUE(Result);
+    UtAssert_BOOL_TRUE(DS_IsPacketFiltered(&Message, FilterType, Alg_N, Alg_X, Alg_O));
 }
 
 void DS_FileTransmit_Test_Nominal(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #125, Adds utassert macro for logging function calls within the coverage tests.

**Testing performed**
- local build and lcov

**Expected behavior changes**
An extra recorded assertion for each function invocation in the coverage tests.

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
