### PR TITLE
Fix #128, Standardize command responses

### DIFF
--- a/fsw/inc/ds_msgdefs.h
+++ b/fsw/inc/ds_msgdefs.h
@@ -70,7 +70,7 @@
  *  \par Command Verification
  *       Evidence of success may be found in the following telemetry:
  *       - #DS_HkTlm_Payload_t.CmdAcceptedCounter will reset to zero
- *       - The #DS_RESET_INF_EID debug event message will be sent
+ *       - The #DS_RESET_INF_EID informational event message will be sent
  *
  *  \par Error Conditions
  *       This command can fail for the following reasons:

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -103,7 +103,7 @@ void DS_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
     DS_AppData.FilterTblLoadCounter = 0;
     DS_AppData.FilterTblErrCounter  = 0;
 
-    CFE_EVS_SendEvent(DS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(DS_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset counters command");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/unit-test/ds_cmds_tests.c
+++ b/unit-test/ds_cmds_tests.c
@@ -91,7 +91,7 @@ void DS_ResetCountersCmd_Test_Nominal(void)
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, DS_RESET_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     /* Verify command struct size minus header is at least explicitly padded to 32-bit boundaries */
     UtAssert_True(CMD_STRUCT_DATA_IS_32_ALIGNED(DS_ResetCountersCmd_t), "DS_ResetCountersCmd_t is 32-bit aligned");


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #128 
  - Updates the type of the reset counters command to `INFORMATION`, rather than `DEBUG`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Reset counters command will be of type `INFORMATION`.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt