### PR TITLE
Fix #127, Adds static analysis comments and replace strncpy with snprintf

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -358,8 +358,7 @@ void DS_AppSendHkCmd(void)
         Status = CFE_TBL_GetInfo(&FilterTblInfo, FilterTblName);
         if (Status == CFE_SUCCESS)
         {
-            strncpy(PayloadPtr->FilterTblFilename, FilterTblInfo.LastFileLoaded, OS_MAX_PATH_LEN - 1);
-            PayloadPtr->FilterTblFilename[OS_MAX_PATH_LEN - 1] = '\0';
+            snprintf(PayloadPtr->FilterTblFilename, OS_MAX_PATH_LEN, "%s", FilterTblInfo.LastFileLoaded);
         }
         else
         {

--- a/fsw/src/ds_appdefs.h
+++ b/fsw/src/ds_appdefs.h
@@ -43,7 +43,7 @@
 
 #define DS_PATH_SEPARATOR '/' /**< \brief File system path separator */
 
-#define DS_TABLE_VERIFY_ERR 0xFFFFFFFF /**< \brief Table verification error return value */
+#define DS_TABLE_VERIFY_ERR -1 /**< \brief Table verification error return value */
 
 #define DS_FILE_HEADER_NONE 0 /**< \brief File header type is NONE */
 #define DS_FILE_HEADER_CFE  1 /**< \brief File header type is CFE */

--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -1096,7 +1096,7 @@ void DS_GetFileInfoCmd(const CFE_SB_Buffer_t *BufPtr)
             /*
             ** Set current open filename...
             */
-            strncpy(FileInfoPtr->FileName, DS_AppData.FileStatus[i].FileName, sizeof(FileInfoPtr->FileName));
+            snprintf(FileInfoPtr->FileName, sizeof(FileInfoPtr->FileName), "%s", DS_AppData.FileStatus[i].FileName);
         }
     }
 

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -881,7 +881,7 @@ void DS_FileCloseDest(int32 FileIndex)
             }
 
             /* Update the path name for reporting */
-            strncpy(FileStatus->FileName, PathName, sizeof(FileStatus->FileName));
+            snprintf(FileStatus->FileName, sizeof(FileStatus->FileName), "%s", PathName);
         }
     }
 
@@ -991,7 +991,7 @@ void DS_FileTransmit(DS_AppFileStatus_t *FileStatus)
         /*
         ** Set current open filename...
         */
-        strncpy(FileInfo->FileName, FileStatus->FileName, sizeof(FileInfo->FileName));
+        snprintf(FileInfo->FileName, sizeof(FileInfo->FileName), "%s", FileStatus->FileName);
 
         /*
         ** Timestamp and send file info telemetry...


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #127, Adds dispositions to line of code in question from static analysis stating why it's safe to keep as-is. Replacing strncpy with snprintf to enhance safety and compliance. Changes DS_TABLE_VERIFY_ERR from 0xFFFFFFFF to -1.

**Testing performed**
Manual Inspection

**Expected behavior changes**
N/A

**System(s) tested on**
N/A

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
