### PR TITLE
Fix nasa#146, When managing the Filter and Dest file tables, the retu…

### DIFF
--- a/fsw/inc/ds_eventids.h
+++ b/fsw/inc/ds_eventids.h
@@ -895,6 +895,18 @@
  */
 #define DS_MID_ERR_EID 73
 
+/**
+ *  \brief CFE_TBL_GetAddress returns an error
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event signals that the DS app had a call to CFE_TBL_GetAddress()
+ *  which returned an error and continuing may cause unexpected behavior.
+ */
+#define DS_TBL_GET_ADDR_ERR_EID 74
+
 /**@}*/
 
 #endif

--- a/fsw/src/ds_table.c
+++ b/fsw/src/ds_table.c
@@ -37,6 +37,12 @@
 
 #define DS_CDS_NAME "DS_CDS"
 
+/*
+ * Local Function Prototypes
+ */
+void TableDestFileUpdate(void);
+void TableFilterUpdate(void);
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* DS application table initialization                             */
@@ -281,21 +287,46 @@ void DS_TableManageDestFile(void)
             */
             CFE_TBL_ReleaseAddress(DS_AppData.DestFileTblHandle);
             CFE_TBL_Update(DS_AppData.DestFileTblHandle);
-            CFE_TBL_GetAddress((void *)&DS_AppData.DestFileTblPtr, DS_AppData.DestFileTblHandle);
-            /*
-            ** Keep local copies of table values that software will modify...
-            */
-            for (i = 0; i < DS_DEST_FILE_CNT; i++)
-            {
-                DS_AppData.FileStatus[i].FileState = DS_AppData.DestFileTblPtr->File[i].EnableState;
-                DS_AppData.FileStatus[i].FileCount = DS_AppData.DestFileTblPtr->File[i].SequenceCount;
-            }
-
-            /*
-            ** Store local values in the Critical Data Store (CDS)...
-            */
-            DS_TableUpdateCDS();
+            TableDestFileUpdate();
         }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Dest File Table Update Local Function                           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void TableDestFileUpdate(void)
+{
+    int32        i = 0;
+    CFE_Status_t Result;
+
+    Result = CFE_TBL_GetAddress((void *)&DS_AppData.DestFileTblPtr, DS_AppData.DestFileTblHandle);
+
+    if (Result >= CFE_SUCCESS)
+    {
+        /*
+        ** Keep local copies of table values that software will modify...
+        */
+        for (i = 0; i < DS_DEST_FILE_CNT; i++)
+        {
+            DS_AppData.FileStatus[i].FileState = DS_AppData.DestFileTblPtr->File[i].EnableState;
+            DS_AppData.FileStatus[i].FileCount = DS_AppData.DestFileTblPtr->File[i].SequenceCount;
+        }
+
+        /*
+        ** Store local values in the Critical Data Store (CDS)...
+        */
+        DS_TableUpdateCDS();
+    }
+    else
+    {
+        CFE_EVS_SendEvent(DS_TBL_GET_ADDR_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "Dest File Table Error for CFE_TBL_GetAddress = 0x%08X",
+                          (unsigned int)Result);
     }
 }
 
@@ -389,17 +420,41 @@ void DS_TableManageFilter(void)
             */
             CFE_TBL_ReleaseAddress(DS_AppData.FilterTblHandle);
             CFE_TBL_Update(DS_AppData.FilterTblHandle);
-            CFE_TBL_GetAddress((void *)&DS_AppData.FilterTblPtr, DS_AppData.FilterTblHandle);
-            /*
-            ** Subscribe to the packets in the new filter table...
-            */
-            DS_TableSubscribe();
-
-            /*
-            ** Create hash table for messageID's in new filter table...
-            */
-            DS_TableCreateHash();
+            TableFilterUpdate();
         }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Filter Table Update Local Function                           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void TableFilterUpdate(void)
+{
+    CFE_Status_t Result;
+
+    Result = CFE_TBL_GetAddress((void *)&DS_AppData.FilterTblPtr, DS_AppData.FilterTblHandle);
+
+    if (Result >= CFE_SUCCESS)
+    {
+        /*
+        ** Subscribe to the packets in the new filter table...
+        */
+        DS_TableSubscribe();
+
+        /*
+        ** Create hash table for messageID's in new filter table...
+        */
+        DS_TableCreateHash();
+    }
+    else
+    {
+        CFE_EVS_SendEvent(DS_TBL_GET_ADDR_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "Filter Table Error for CFE_TBL_GetAddress = 0x%08X",
+                          (unsigned int)Result);
     }
 }
 

--- a/unit-test/ds_table_tests.c
+++ b/unit-test/ds_table_tests.c
@@ -244,6 +244,14 @@ void DS_TableManageDestFile_Test_TableInfoUpdatePending(void)
     UtAssert_UINT32_EQ(DS_AppData.FileStatus[DS_DEST_FILE_CNT - 1].FileCount, DS_DEST_FILE_CNT - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* Execute the function with CFE_TBL_GetAddress() Failing */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
+
+    /* Execute the function being tested */
+    DS_TableManageDestFile();
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void DS_TableManageDestFile_Test_TableSuccess(void)
@@ -345,6 +353,15 @@ void DS_TableManageFilter_Test_TableInfoUpdatePending(void)
     UtAssert_UINT32_EQ(DS_AppData.FilterTblLoadCounter, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* If CFE_TBL_GetAddress() fails */
+    /* Execute the function with CFE_TBL_GetAddress() Failing */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
+
+    /* Execute the function being tested */
+    DS_TableManageFilter();
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void DS_TableManageFilter_Test_TableSuccess(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
When managing the Filter and Dest file tables, the return value of CFE_TBL_GetAddress() after the tables have already been loaded will be checked.  Fixes nasa#146

**Testing performed**
Updated and ran the unit tests `DS_TableManageDestFile_Test_TableInfoUpdatePending()` and `DS_TableManageFilter_Test_TableInfoUpdatePending()` in `unit-test/ds_table_tests.c`

**Expected behavior changes**
 - If either the dest file and filter tables have already been loaded and there is an update pending but the call to CFE_TBL_GetAddress() fails, an error event message (id = DS_TBL_GET_ADDR_ERR_EID) will be issued.  

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang, NASA/GSFC
