### PR TITLE
Fix nasa#148, DS App strcpy does not check bound.

### DIFF
--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -621,10 +621,7 @@ void DS_FileCreateName(uint32 FileIndex)
         /* Confirm working name fits */
         if (strlen(Workname) < sizeof(FileStatus->FileName))
         {
-            /* 
-            ** SAD: This should be ignored by CodeSonar.
-            ** strcpy is OK because bounds checking was performed above. 
-             */
+            /* SAD: Ignore CodeSonar - strcpy ok as bounds checking was performed above */
             strcpy(FileStatus->FileName, Workname);
         }
         else

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -619,12 +619,10 @@ void DS_FileCreateName(uint32 FileIndex)
         }
 
         /* Confirm working name fits */
-        if (strlen(Workname) < DS_TOTAL_FNAME_BUFSIZE)
+        if (strlen(Workname) < sizeof(FileStatus->FileName))
         {
-            /* Success - copy workname to filename buffer */
-            strncpy(FileStatus->FileName, Workname, sizeof(FileStatus->FileName) - 1);
-            /* Make sure a null terminator is added to the strncpy destination */
-            FileStatus->FileName[sizeof(FileStatus->FileName) - 1] = '\0';
+            /* note: strcpy is OK because bounds checking was performed above. */
+            strcpy(FileStatus->FileName, Workname);
         }
         else
         {

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -622,7 +622,9 @@ void DS_FileCreateName(uint32 FileIndex)
         if (strlen(Workname) < DS_TOTAL_FNAME_BUFSIZE)
         {
             /* Success - copy workname to filename buffer */
-            strncpy(FileStatus->FileName, Workname, sizeof(FileStatus->FileName));
+            strncpy(FileStatus->FileName, Workname, sizeof(FileStatus->FileName) - 1);
+            /* Make sure a null terminator is added to the strncpy destination */
+            FileStatus->FileName[sizeof(FileStatus->FileName) - 1] = '\0';
         }
         else
         {

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -622,7 +622,7 @@ void DS_FileCreateName(uint32 FileIndex)
         if (strlen(Workname) < DS_TOTAL_FNAME_BUFSIZE)
         {
             /* Success - copy workname to filename buffer */
-            strcpy(FileStatus->FileName, Workname);
+            strncpy(FileStatus->FileName, Workname, sizeof(FileStatus->FileName));
         }
         else
         {

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -621,7 +621,6 @@ void DS_FileCreateName(uint32 FileIndex)
         /* Confirm working name fits */
         if (strlen(Workname) < sizeof(FileStatus->FileName))
         {
-            /* SAD: Ignore CodeSonar - strcpy ok as bounds checking was performed above */
             strcpy(FileStatus->FileName, Workname);
         }
         else

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -621,8 +621,9 @@ void DS_FileCreateName(uint32 FileIndex)
         /* Confirm working name fits */
         if (strlen(Workname) < sizeof(FileStatus->FileName))
         {
-            /* note: strcpy is OK because bounds checking was performed above. 
-             * SAD: This should be ignored by CodeSonar.
+            /* 
+            ** SAD: This should be ignored by CodeSonar.
+            ** strcpy is OK because bounds checking was performed above. 
              */
             strcpy(FileStatus->FileName, Workname);
         }

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -621,7 +621,9 @@ void DS_FileCreateName(uint32 FileIndex)
         /* Confirm working name fits */
         if (strlen(Workname) < sizeof(FileStatus->FileName))
         {
-            /* note: strcpy is OK because bounds checking was performed above. */
+            /* note: strcpy is OK because bounds checking was performed above. 
+             * SAD: This should be ignored by CodeSonar.
+             */
             strcpy(FileStatus->FileName, Workname);
         }
         else


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov. (This issue was discussed in a cfs meeting. I think that counts!)

**Describe the contribution**
Static analyzer via CodeSonar found a usage of 'strcpy' the DS App. Strcpy() does not check bounds and should be replaced with something that does like strncpy(). strncpy(dest, src, sizeof(dest));
Fixes #148 

**More Info**
Code Sonar error: BADFUNC.BO.STRCPY : Use of strcpy
Summary: A use of strcpy() or a similar function (see full list below), which are vulnerable to buffer overflows.
Resolution: Use a function that does bounds checking, such as strncpy(), StrCbCopy(), or StrCchCopy().

The issue seems to be a concern over buffer overflow. The source string being copied over to a destination string could potentially cause issues if, for example, the source string doesn't have a null terminator for some reason. That would mean garbage could potentially be added into the destination string.

Strncpy can add null characters, omit them, and pad them depending on the size you pass.
If the source string is shorter than n, strncpy copies it and pads with null characters until n bytes.
If the source string length is equal to or longer than n, strncpy copies exactly n bytes with NO null terminator.
Because of this, you must always add a terminator yourself when using strncpy for string copying.

Common practice while using strncpy:
strncpy(dest, src, sizeof(dest) - 1); //sizeof()-1 makes sure there will be room for null terminator
dest[sizeof(dest) - 1] = '\0'; //make sure the destination string has a null terminator

**Testing performed**
1. make distclean
2. make native_std.prep
3. make native_std.install
4. make native_std.runtest
5. cd build-native_std/native/default_cpu1/
6. ctest
7. run Cosmos
8. Note: I still can't log into CodeSonar to check the static analysis results. It would be great if a reviewer could check what CodeSonar has to say.