### PR TITLE
Fix #150, Initialize Buffer in DS_FileCreateSequence

### DIFF
--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -698,6 +698,8 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
     }
     else if (Type == DS_BY_TIME)
     {
+        memset(Buffer, 0, CFE_TIME_PRINTED_STRING_SIZE);
+
         /*
         ** Filename is based on seconds from current time...
         */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #150 

**Testing performed**
GitHub Actions and CodeSonar

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket.

**Additional context**
Codesonar warning is gone, but replaced with Use of memset


**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.