### PR TITLE
Fix #153, use sizeof for snprintf buffer sizes in DS_SendHkCmd

### DIFF
--- a/fsw/src/ds_cmds.c
+++ b/fsw/src/ds_cmds.c
@@ -1526,13 +1526,16 @@ CFE_Status_t DS_SendHkCmd(const DS_SendHkCmd_t *BufPtr)
     }
 
     /* Get the filter table info, put the file name in the HK pkt. */
-    Status = snprintf(FilterTblName, CFE_MISSION_TBL_MAX_NAME_LENGTH, "DS.%s", DS_FILTER_TBL_NAME);
+    Status = snprintf(FilterTblName, sizeof(FilterTblName), "DS.%s", DS_FILTER_TBL_NAME);
     if (Status >= 0)
     {
         Status = CFE_TBL_GetInfo(&FilterTblInfo, FilterTblName);
         if (Status == CFE_SUCCESS)
         {
-            snprintf(PayloadPtr->FilterTblFilename, OS_MAX_PATH_LEN, "%s", FilterTblInfo.LastFileLoaded);
+            snprintf(PayloadPtr->FilterTblFilename,
+                     sizeof(PayloadPtr->FilterTblFilename),
+                     "%s",
+                     FilterTblInfo.LastFileLoaded);
         }
         else
         {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #153, sets the buffer allocation to match the actual size of the destination buffer

**Testing performed**
build, tests, lcov

**Expected behavior changes**
Nothing functional. Ensures write limit is derived directly from the destination buffer's declared size. Prevents overflow of truncation in the event of a user changing the configuration.

**System(s) tested on**
 - Hardware: aarch64
 - OS: Ubuntu 24.04.4 LTS
 - Versions 0cd8596f213183726506049cf2203fc197d54b35 commit of apps/ds + 38eaf4244185bc70aa296f1d8df7687e2f13989d cFS bundle

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems Inc
