### PR TITLE
Fix #155, Prevent DS app exit on CFE_SB_NO_MESSAGE

### DIFF
--- a/fsw/src/ds_app.c
+++ b/fsw/src/ds_app.c
@@ -123,6 +123,10 @@ void DS_AppMain(void)
             DS_TableManageDestFile();
             DS_TableManageFilter();
         }
+        else if (Result == CFE_SB_NO_MESSAGE)
+        {
+            /* no action, but also no error */
+        }
         else
         {
             /*

--- a/unit-test/ds_app_tests.c
+++ b/unit-test/ds_app_tests.c
@@ -140,6 +140,22 @@ void DS_AppMain_Test_SBTimeout(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 }
 
+void DS_AppMain_Test_SBNoMessage(void)
+{
+    /* Set to exit loop after first run */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_ES_RunLoop), true);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_RunLoop), 2, false);
+
+    /* Set to satisfy subsequent condition "Result == CFE_SB_NO_MESSAGE" immediately after call to CFE_SB_RcvMsg */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
+
+    /* Execute the function being tested */
+    UtAssert_VOIDCALL(DS_AppMain());
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+}
+
 void DS_AppInitialize_Test_Nominal(void)
 {
     memset(&DS_AppData, 1, sizeof(DS_AppData));
@@ -344,6 +360,7 @@ void UtTest_Setup(void)
     UT_DS_TEST_ADD(DS_AppMain_Test_AppInitializeError);
     UT_DS_TEST_ADD(DS_AppMain_Test_SBError);
     UT_DS_TEST_ADD(DS_AppMain_Test_SBTimeout);
+    UT_DS_TEST_ADD(DS_AppMain_Test_SBNoMessage);
 
     UT_DS_TEST_ADD(DS_AppInitialize_Test_Nominal);
     UT_DS_TEST_ADD(DS_AppInitialize_Test_EVSRegisterError);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
-Fixes #155

**Testing performed**
build, run, test

**Expected behavior changes**
No app exit on no cfe sb message.

**System(s) tested on**
 - Hardware: aarch64
 - OS: Ubuntu 24.04.4 LTS
 - Versions 0cd8596f213183726506049cf2203fc197d54b35 commit of apps/ds + 38eaf4244185bc70aa296f1d8df7687e2f13989d cFS bundle
 
**Additional context**
Add any other context about the contribution here.

**Third party code**
Inherited from lunar gateway

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems Inc
