### PR TITLE
Fix #131: remove duplicate header and includes in ds_dispatch.c

### DIFF
--- a/fsw/src/ds_dispatch.c
+++ b/fsw/src/ds_dispatch.c
@@ -37,45 +37,6 @@
 
 #include <stdio.h>
 
-/************************************************************************
- * NASA Docket No. GSC-18,917-1, and identified as “CFS Data Storage
- * (DS) application version 2.6.1”
- *
- * Copyright (c) 2021 United States Government as represented by the
- * Administrator of the National Aeronautics and Space Administration.
- * All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain
- * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- ************************************************************************/
-
-/**
- * @file
- *  CFS Data Storage (DS) command handler functions
- */
-
-#include "cfe.h"
-
-#include "ds_platform_cfg.h"
-#include "ds_verify.h"
-
-#include "ds_appdefs.h"
-#include "ds_msgids.h"
-#include "ds_eventids.h"
-
-#include "ds_msg.h"
-#include "ds_app.h"
-#include "ds_cmds.h"
-
-#include <stdio.h>
-
 bool DS_VerifyLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength, uint16 FailEventID, const char *CommandName)
 {
     size_t ActualLength = 0;


### PR DESCRIPTION
## Summary

Remove the duplicate copyright header and `#include` block in `ds_dispatch.c`.

## Problem

`ds_dispatch.c` contains two consecutive copyright headers and two sets of
`#include` directives. The first block (lines 1-38) is the current Draco
header with the correct includes for the dispatch module. The second block
(lines 40-78) is an older DS v2.6.1 header with includes from what was
previously `ds_cmds.c`, likely left behind during a refactor.

The duplicate `#include <stdio.h>` and duplicate `#include "ds_msgids.h"` etc.
are harmless to the compiler (include guards prevent double inclusion) but
are clearly unintended.

## Fix

Delete the second block (39 lines). The first header and its includes are
preserved unchanged. Zero functional change.

Fixes #131.
